### PR TITLE
Split tests files to link against 'main' test runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           cmake --build build/
 
       - name: Test C++
-        run: ./build/tests_intersections
+        run: ./build/run_tests
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,10 @@ set(CPP_SRC_DIR src/cpp)
 set(CPP_TESTS_DIR tests/cpp)
 
 add_subdirectory(${CPP_TESTS_DIR}/lib/Catch2)
-add_executable(tests_intersections
+add_executable(run_tests
+  ${CPP_TESTS_DIR}/run_tests.cpp
   ${CPP_TESTS_DIR}/tests_intersections.cpp
   ${CPP_SRC_DIR}/find_intersections_linestring.cpp
   )
-target_include_directories(tests_intersections PUBLIC ${CPP_SRC_DIR})
-target_link_libraries(tests_intersections PRIVATE Catch2::Catch2)
+target_include_directories(run_tests PUBLIC ${CPP_SRC_DIR})
+target_link_libraries(run_tests PRIVATE Catch2::Catch2)

--- a/tests/cpp/run_tests.cpp
+++ b/tests/cpp/run_tests.cpp
@@ -1,0 +1,5 @@
+// This tells Catch to provide a main()
+// only do this in one cpp file
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+// Leave this file empty of test cases - other test files will link against it.

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -1,8 +1,3 @@
-// This tells Catch to provide a main()
-// only do this in one cpp file
-#define CATCH_CONFIG_MAIN
-#define TOL 0.001
-
 #include <catch2/catch.hpp>
 #include <fstream>
 #include <iostream>
@@ -14,6 +9,8 @@
 #include "geom.hpp"
 #include "raster.hpp"
 #include "find_intersections_linestring.hpp"
+
+#define TOL 0.001
 
 using linestr = std::vector<geometry::Vec2<double>>;
 


### PR DESCRIPTION
In anticipation of adding more files with test cases - I think we will want a single "test runner" and a bunch of files with test cases in them, following https://github.com/catchorg/Catch2/blob/devel/docs/tutorial.md#scaling-up