### PR TITLE
Grid abstraction with affine transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ __pycache__
 *.egg-info
 .coverage
 
+# Editor
+.vscode
+
 # Data
 data
 *.asc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,6 @@ add_executable(run_tests
   ${CPP_TESTS_DIR}/run_tests.cpp
   ${CPP_TESTS_DIR}/tests_intersections.cpp
   ${CPP_SRC_DIR}/find_intersections_linestring.cpp
-  )
+)
 target_include_directories(run_tests PUBLIC ${CPP_SRC_DIR})
 target_link_libraries(run_tests PRIVATE Catch2::Catch2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ add_subdirectory(${CPP_TESTS_DIR}/lib/Catch2)
 add_executable(run_tests
   ${CPP_TESTS_DIR}/run_tests.cpp
   ${CPP_TESTS_DIR}/tests_intersections.cpp
+  ${CPP_TESTS_DIR}/tests_transform.cpp
   ${CPP_SRC_DIR}/find_intersections_linestring.cpp
 )
 target_include_directories(run_tests PUBLIC ${CPP_SRC_DIR})

--- a/src/cpp/exceptions.hpp
+++ b/src/cpp/exceptions.hpp
@@ -15,7 +15,7 @@ private:
 public:
   Exception(const std::string s) : e(s) {
     std::cout << "ERROR: " << e << "\n";
-    throw;
+    throw std::runtime_error(s);
   }
 
 private:

--- a/src/cpp/find_intersections_linestring.cpp
+++ b/src/cpp/find_intersections_linestring.cpp
@@ -1,6 +1,6 @@
 #include "geofeatures.hpp"
 #include "geom.hpp"
-#include "raster.hpp"
+#include "grid.hpp"
 
 using linestr = std::vector<geometry::Vec2<double>>;
 
@@ -22,7 +22,7 @@ std::vector<linestr> split_linestr(linestr linestring, linestr intersections) {
 
 /// Find intersection points of a linestring with a raster grid
 std::vector<linestr> findIntersectionsLineString(Feature feature,
-                                                 Ascii raster) {
+                                                 Grid raster) {
   linestr linestring = feature.geometry;
 
   std::vector<linestr> allsplits;

--- a/src/cpp/find_intersections_linestring.hpp
+++ b/src/cpp/find_intersections_linestring.hpp
@@ -1,1 +1,1 @@
-std::vector<std::vector<geometry::Vec2<double>>> findIntersectionsLineString(Feature, Ascii);
+std::vector<std::vector<geometry::Vec2<double>>> findIntersectionsLineString(Feature, Grid);

--- a/src/cpp/grid.hpp
+++ b/src/cpp/grid.hpp
@@ -1,6 +1,7 @@
 #ifndef GRID_H
 #define GRID_H
 
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -43,8 +44,11 @@ struct Grid {
   }
 
   /// Recover i, j index in raster.
-  geometry::Vec2<int> cellIndices(const geometry::Vec2<double> p) const {
-    auto offset = world_to_grid * p;
+  geometry::Vec2<int>
+  cellIndices(const geometry::Vec2<double> p,
+              double epsilon = std::numeric_limits<double>::epsilon()) const {
+    auto offset =
+        world_to_grid * (p + geometry::Vec2<double>(epsilon, epsilon));
     return geometry::Vec2<int>(floor(offset.x), floor(offset.y));
   }
 

--- a/src/cpp/grid.hpp
+++ b/src/cpp/grid.hpp
@@ -39,8 +39,8 @@ struct Grid {
 
   /// Calculate hashed index in raster.
   int cellIndex(const geometry::Vec2<double> p) const {
-    auto offset = world_to_grid * p;
-    return floor(offset.x) + floor(offset.y) * ncols;
+    auto offset = cellIndices(p);
+    return offset.x + offset.y * ncols;
   }
 
   /// Recover i, j index in raster.
@@ -125,7 +125,6 @@ struct Grid {
     // the start and end of the line.
     return crossings;
   }
-
 };
 
 #endif // GRID_H

--- a/src/cpp/grid.hpp
+++ b/src/cpp/grid.hpp
@@ -23,19 +23,22 @@ struct Grid {
   std::vector<double> data;
 
   Grid()
-    :ncols{0}, nrows{0}, grid_to_world{Affine()}, data{std::vector<double>()} {
-      world_to_grid = ~grid_to_world;
-    };
+      : ncols{0}, nrows{0},
+        grid_to_world{Affine()}, data{std::vector<double>()} {
+    world_to_grid = ~grid_to_world;
+  };
 
   Grid(size_t ncols, size_t nrows, Affine grid_to_world)
-    :ncols{ncols}, nrows{nrows}, grid_to_world{grid_to_world}, data{std::vector<double>()} {
-      world_to_grid = ~grid_to_world;
-    };
+      : ncols{ncols}, nrows{nrows},
+        grid_to_world{grid_to_world}, data{std::vector<double>()} {
+    world_to_grid = ~grid_to_world;
+  };
 
-  Grid(size_t ncols, size_t nrows, Affine grid_to_world, std::vector<double> data)
-    :ncols{ncols}, nrows{nrows}, grid_to_world{grid_to_world}, data{data} {
-      world_to_grid = ~grid_to_world;
-    };
+  Grid(size_t ncols, size_t nrows, Affine grid_to_world,
+       std::vector<double> data)
+      : ncols{ncols}, nrows{nrows}, grid_to_world{grid_to_world}, data{data} {
+    world_to_grid = ~grid_to_world;
+  };
 
   /// Calculate hashed index in raster.
   int cellIndex(const geometry::Vec2<double> p) const {

--- a/src/cpp/grid.hpp
+++ b/src/cpp/grid.hpp
@@ -50,6 +50,9 @@ struct Grid {
   geometry::Vec2<int>
   cellIndices(const geometry::Vec2<double> p,
               double epsilon = std::numeric_limits<double>::epsilon()) const {
+    // Note on epsilon: nudge point slightly in the x and y direction towards the cell centre
+    // - this should allow for some tolerance in coordinate precision and avoid off-by-one errors
+    // TODO confirm and construct test case to demonstrate.
     auto offset =
         world_to_grid * (p + geometry::Vec2<double>(epsilon, epsilon));
     return geometry::Vec2<int>(floor(offset.x), floor(offset.y));

--- a/src/cpp/grid.hpp
+++ b/src/cpp/grid.hpp
@@ -1,5 +1,5 @@
-#ifndef RASTER_H
-#define RASTER_H
+#ifndef GRID_H
+#define GRID_H
 
 #include <string>
 #include <vector>
@@ -7,17 +7,23 @@
 #include "geom.hpp"
 #include "utils.hpp"
 
-/// Structure defining an ESRI Ascii raster.
-struct Ascii {
-  int ncols;       // number of columns in the Ascii Raster
-  int nrows;       // number of rows in the Ascii Raster
-  double xll;      // xl corner of the Ascii Raster
-  double yll;      // yll corner of the Ascii Raster
-  double cellsize; // x, y cell dimension of the incoming data
-  double nodata;   // value taken as "no data"
-  // 1D vector of doubles storing the data in the Ascii Raster
+/// Structure defining a raster grid.
+struct Grid {
+  /// number of columns
+  int ncols;
+  /// number of rows
+  int nrows;
+  /// xll corner
+  double xll;
+  /// yll corner
+  double yll;
+  /// x, y cell dimension of the incoming data
+  double cellsize;
+  /// value taken as "no data"
+  double nodata;
+  /// 1D vector of doubles storing the data (conceptually a 2D grid)
   std::vector<double> data;
-  // For convenience, store the number of cells (calculated)
+  /// For convenience, store the number of cells (calculated)
   int numCells;
 
   /// Read and interpret a line in the ascii header.
@@ -131,7 +137,7 @@ struct Ascii {
   }
 
   /// Construct by reading from file
-  Ascii(const std::string filename) {
+  Grid(const std::string filename) {
     // Test if the ascii raster exists.
     if (!utils::exists(filename))
       utils::Exception(
@@ -175,4 +181,4 @@ struct Ascii {
   }
 };
 
-#endif // RASTER_H
+#endif // GRID_H

--- a/src/cpp/transform.hpp
+++ b/src/cpp/transform.hpp
@@ -50,6 +50,13 @@ struct Affine {
         );
     }
 
+    geometry::Vec2<double> operator*(const geometry::Vec2<int> &p) const {
+        return geometry::Vec2<double>(
+            p.x * a + p.y * b + c,
+            p.x * d + p.y * e + f
+        );
+    }
+
 };
 
 #endif // TRANSFORM_H

--- a/src/cpp/transform.hpp
+++ b/src/cpp/transform.hpp
@@ -1,0 +1,55 @@
+#ifndef TRANSFORM_H
+#define TRANSFORM_H
+
+#include "exceptions.hpp"
+#include "geom.hpp"
+
+struct Affine {
+    double a;
+    double b;
+    double c;
+    double d;
+    double e;
+    double f;
+
+    /// Default construct identity transform
+    Affine()
+        :a{1}, b{0}, c{0}, d{0}, e{1}, f{0} {};
+
+    /// Construct with six parameters, first two rows of 3x3 matrix
+    Affine(double a, double b, double c, double d, double e, double f)
+        :a{a}, b{b}, c{c}, d{d}, e{e}, f{f} {};
+
+    /// Construct from GDALGeoTransform ordering of parameters
+    static Affine from_gdal(double c, double a, double b, double f, double d, double e) {
+        return Affine(a, b, c, d, e, f);
+    }
+
+    /// Invert transform
+    /// see https://en.wikipedia.org/wiki/Invertible_matrix#Inversion_of_3_%C3%97_3_matrices
+    /// and simplify since bottom row (g, h, i) is always (0, 0, 1)
+    Affine operator~() {
+        double determinant = a * e - b * d;
+        if (determinant == 0) {
+            utils::Exception("The transform is not invertible");
+        }
+        double inverse_a = e / determinant;
+        double inverse_b = -b / determinant;
+        double inverse_d = -d / determinant;
+        double inverse_e = a / determinant;
+        double inverse_c = -c * inverse_a - f * inverse_b;
+        double inverse_f = -c * inverse_d - f * inverse_e;
+        return Affine(inverse_a, inverse_b, inverse_c, inverse_d, inverse_e, inverse_f);
+    }
+
+    /// Apply transform to a 2-dimensional point
+    geometry::Vec2<double> operator*(const geometry::Vec2<double> &p) const {
+        return geometry::Vec2<double>(
+            p.x * a + p.y * b + c,
+            p.x * d + p.y * e + f
+        );
+    }
+
+};
+
+#endif // TRANSFORM_H

--- a/src/cpp/transform.hpp
+++ b/src/cpp/transform.hpp
@@ -5,58 +5,53 @@
 #include "geom.hpp"
 
 struct Affine {
-    double a;
-    double b;
-    double c;
-    double d;
-    double e;
-    double f;
+  double a;
+  double b;
+  double c;
+  double d;
+  double e;
+  double f;
 
-    /// Default construct identity transform
-    Affine()
-        :a{1}, b{0}, c{0}, d{0}, e{1}, f{0} {};
+  /// Default construct identity transform
+  Affine() : a{1}, b{0}, c{0}, d{0}, e{1}, f{0} {};
 
-    /// Construct with six parameters, first two rows of 3x3 matrix
-    Affine(double a, double b, double c, double d, double e, double f)
-        :a{a}, b{b}, c{c}, d{d}, e{e}, f{f} {};
+  /// Construct with six parameters, first two rows of 3x3 matrix
+  Affine(double a, double b, double c, double d, double e, double f)
+      : a{a}, b{b}, c{c}, d{d}, e{e}, f{f} {};
 
-    /// Construct from GDALGeoTransform ordering of parameters
-    static Affine from_gdal(double c, double a, double b, double f, double d, double e) {
-        return Affine(a, b, c, d, e, f);
+  /// Construct from GDALGeoTransform ordering of parameters
+  static Affine from_gdal(double c, double a, double b, double f, double d,
+                          double e) {
+    return Affine(a, b, c, d, e, f);
+  }
+
+  /// Invert transform
+  /// see
+  /// https://en.wikipedia.org/wiki/Invertible_matrix#Inversion_of_3_%C3%97_3_matrices
+  /// and simplify since bottom row (g, h, i) is always (0, 0, 1)
+  Affine operator~() {
+    double determinant = a * e - b * d;
+    if (determinant == 0) {
+      utils::Exception("The transform is not invertible");
     }
+    double inverse_a = e / determinant;
+    double inverse_b = -b / determinant;
+    double inverse_d = -d / determinant;
+    double inverse_e = a / determinant;
+    double inverse_c = -c * inverse_a - f * inverse_b;
+    double inverse_f = -c * inverse_d - f * inverse_e;
+    return Affine(inverse_a, inverse_b, inverse_c, inverse_d, inverse_e,
+                  inverse_f);
+  }
 
-    /// Invert transform
-    /// see https://en.wikipedia.org/wiki/Invertible_matrix#Inversion_of_3_%C3%97_3_matrices
-    /// and simplify since bottom row (g, h, i) is always (0, 0, 1)
-    Affine operator~() {
-        double determinant = a * e - b * d;
-        if (determinant == 0) {
-            utils::Exception("The transform is not invertible");
-        }
-        double inverse_a = e / determinant;
-        double inverse_b = -b / determinant;
-        double inverse_d = -d / determinant;
-        double inverse_e = a / determinant;
-        double inverse_c = -c * inverse_a - f * inverse_b;
-        double inverse_f = -c * inverse_d - f * inverse_e;
-        return Affine(inverse_a, inverse_b, inverse_c, inverse_d, inverse_e, inverse_f);
-    }
+  /// Apply transform to a 2-dimensional point
+  geometry::Vec2<double> operator*(const geometry::Vec2<double> &p) const {
+    return geometry::Vec2<double>(p.x * a + p.y * b + c, p.x * d + p.y * e + f);
+  }
 
-    /// Apply transform to a 2-dimensional point
-    geometry::Vec2<double> operator*(const geometry::Vec2<double> &p) const {
-        return geometry::Vec2<double>(
-            p.x * a + p.y * b + c,
-            p.x * d + p.y * e + f
-        );
-    }
-
-    geometry::Vec2<double> operator*(const geometry::Vec2<int> &p) const {
-        return geometry::Vec2<double>(
-            p.x * a + p.y * b + c,
-            p.x * d + p.y * e + f
-        );
-    }
-
+  geometry::Vec2<double> operator*(const geometry::Vec2<int> &p) const {
+    return geometry::Vec2<double>(p.x * a + p.y * b + c, p.x * d + p.y * e + f);
+  }
 };
 
 #endif // TRANSFORM_H

--- a/src/cpp/transform.hpp
+++ b/src/cpp/transform.hpp
@@ -45,10 +45,11 @@ struct Affine {
     if (determinant == 0) {
       utils::Exception("The transform is not invertible");
     }
-    double inverse_a = e / determinant;
-    double inverse_b = -b / determinant;
-    double inverse_d = -d / determinant;
-    double inverse_e = a / determinant;
+    double ideterminant = 1 / determinant;
+    double inverse_a = e * ideterminant;
+    double inverse_b = -b * ideterminant;
+    double inverse_d = -d * ideterminant;
+    double inverse_e = a * ideterminant;
     double inverse_c = -c * inverse_a - f * inverse_b;
     double inverse_f = -c * inverse_d - f * inverse_e;
     return Affine(inverse_a, inverse_b, inverse_c, inverse_d, inverse_e,

--- a/src/cpp/transform.hpp
+++ b/src/cpp/transform.hpp
@@ -4,6 +4,15 @@
 #include "exceptions.hpp"
 #include "geom.hpp"
 
+/**
+ * Affine transform
+ *
+ * Represents a 2D transform, can be a linear transformation plus translation,
+ * including scaling, rotation, translation or shear.
+ *
+ * This holds all the metadata needed to define world-to-grid or grid-to-world
+ * coordinate transformations for a raster::Grid.
+ */
 struct Affine {
   double a;
   double b;
@@ -20,6 +29,8 @@ struct Affine {
       : a{a}, b{b}, c{c}, d{d}, e{e}, f{f} {};
 
   /// Construct from GDALGeoTransform ordering of parameters
+  /// see
+  /// https://gdal.org/api/gdaldataset_cpp.html#_CPPv4N11GDALDataset15GetGeoTransformEPd
   static Affine from_gdal(double c, double a, double b, double f, double d,
                           double e) {
     return Affine(a, b, c, d, e, f);

--- a/src/cpp/utils.hpp
+++ b/src/cpp/utils.hpp
@@ -1,14 +1,6 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-#include <algorithm>
-#include <fstream>
-#include <sstream>
-#include <string>
-#include <vector>
-
-#include "exceptions.hpp"
-
 namespace utils {
 
 /// π
@@ -20,99 +12,6 @@ const double R = 6371.0;
 /// conversion from degrees to radians
 const double toRad = PI / 180.0;
 
-/// Determine if a file exists
-inline bool exists(const std::string &name) {
-  std::ifstream f(name.c_str());
-  return f.good();
-}
-
-/// Determine a MapInfo file exists (both parts).
-inline void mifExists(const std::string &name) {
-  // Take a local copy, for purpose of DRY.
-  std::string _name = name;
-  if (_name.find(".mif") != std::string::npos ||
-      _name.find(".mid") != std::string::npos)
-    _name = _name.substr(0, _name.length() - 4);
-
-  // Test that both parts of the MIF file exist.
-  if (!exists(_name + ".mif"))
-    Exception("File missing: " + _name + ".mif");
-
-  if (!exists(_name + ".mid"))
-    Exception("File missing: " + _name + ".mid");
-}
-
-/// Make a string lower-case.
-inline std::string lower_case(const std::string s) {
-  std::string l_s = s;
-  std::transform(l_s.begin(), l_s.end(), l_s.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-  return l_s;
-}
-
-/// Read a line of delimited text into vector of strings,
-/// respecting any strings that may have delimiters in quotes.
-inline std::vector<std::string> readLine(const std::string line,
-                                         const char delim = ',',
-                                         const bool stripQuotes = false) {
-  std::stringstream ss(line);
-
-  // Create some space to store the words in the incoming line.
-  std::vector<std::string> words;
-  std::string word;
-
-  // Parse the incoming line, respecting delims as requested.
-  while (std::getline(ss, word, delim)) {
-    if (word.size() > 0) {
-      // If needed, strip the quotes from a word.
-      if (stripQuotes)
-        word.erase(remove(word.begin(), word.end(), '\"'), word.end());
-      // Stick it on the tab.
-      words.push_back(word);
-    }
-  }
-
-  // Loop through the words, and check for any unhandled open-quotes which
-  // indicates delimters were included between quotes.
-  std::vector<std::string> fixedWords;
-  // Flag to indicate we need to append neighboring words.
-  bool append = false;
-  for (std::size_t i = 0; i < words.size(); i++) {
-    // Count the number of open-quotes in the string.
-    int numSQ = 0, numDQ = 0;
-    // Look for quotes...
-    for (auto c : words.at(i)) {
-      if (c == '\'')
-        numSQ++;
-      if (c == '\"')
-        numDQ++;
-    }
-
-    // Append words if odd-numbers of any type of quote characters.
-    if (append) {
-      fixedWords.at(fixedWords.size() - 1) =
-          fixedWords.at(fixedWords.size() - 1) + "," + words.at(i);
-    } else {
-      fixedWords.push_back(words.at(i));
-    }
-
-    // Update the append flag f or the next go around.
-    if (numDQ % 2 != 0 || numSQ % 2 != 0) {
-      append = !append;
-    }
-  }
-
-  return fixedWords;
-}
-
-/// Write a data buffer to disk (NOTE: this is done to
-/// keep the memory footprint down for large study areas).
-template <typename T>
-inline void writeBuffer(const std::vector<T> &data, const std::string f) {
-  std::ofstream b(f, std::ios::out | std::ios::binary);
-  b.write((char *)&data[0], data.size() * sizeof(T));
-  b.close();
-}
 } // namespace utils
 
 #endif // UTILS_H

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -8,10 +8,8 @@
 
 #include "geofeatures.hpp"
 #include "geom.hpp"
-#include "raster.hpp"
+#include "grid.hpp"
 #include "find_intersections_linestring.hpp"
-
-#define TOL 0.001
 
 #define TOL 0.001
 
@@ -84,7 +82,7 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
   linestr geom = test_data.linestring;;
   f.geometry.insert(f.geometry.begin(), geom.begin(), geom.end());
 
-  Ascii test_raster("./tests/test_data/fake_raster.asc");
+  Grid test_raster("./tests/test_data/fake_raster.asc");
   std::vector<linestr> splits = findIntersectionsLineString(f, test_raster);
 
   // Test that we're getting the expected number of splits

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -13,6 +13,8 @@
 
 #define TOL 0.001
 
+#define TOL 0.001
+
 using linestr = std::vector<geometry::Vec2<double>>;
 
 struct Config {

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -9,6 +9,7 @@
 #include "geofeatures.hpp"
 #include "geom.hpp"
 #include "grid.hpp"
+#include "transform.hpp"
 #include "find_intersections_linestring.hpp"
 
 #define TOL 0.001
@@ -82,7 +83,8 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
   linestr geom = test_data.linestring;;
   f.geometry.insert(f.geometry.begin(), geom.begin(), geom.end());
 
-  Grid test_raster("./tests/test_data/fake_raster.asc");
+  // Using default Affine transform(1, 0, 0, 0, 1, 0)
+  Grid test_raster(2, 2, Affine());
   std::vector<linestr> splits = findIntersectionsLineString(f, test_raster);
 
   // Test that we're getting the expected number of splits

--- a/tests/cpp/tests_transform.cpp
+++ b/tests/cpp/tests_transform.cpp
@@ -63,6 +63,13 @@ TEST_CASE("Invert okay", "[invert]") {
     REQUIRE( a_again.f == Approx(2));
 }
 
+TEST_CASE("Invert fails with zero determinant", "[invert]") {
+    Affine a(0, 0, 0, 0, 0, 0);
+    REQUIRE_THROWS_WITH( ~a, "The transform is not invertible" );
+    Affine b(2, 1, 0, 2, 1, 0);
+    REQUIRE_THROWS_WITH( ~b, "The transform is not invertible" );
+}
+
 TEST_CASE("Invert translation", "[invert]") {
     double x = 2;
     double y = 4;

--- a/tests/cpp/tests_transform.cpp
+++ b/tests/cpp/tests_transform.cpp
@@ -1,0 +1,112 @@
+#include <catch2/catch.hpp>
+
+#include "geom.hpp"
+#include "transform.hpp"
+
+TEST_CASE("Default is identity", "[construction]") {
+    Affine(a);
+    REQUIRE( a.a == 1 );
+    REQUIRE( a.b == 0 );
+    REQUIRE( a.c == 0 );
+    REQUIRE( a.d == 0 );
+    REQUIRE( a.e == 1 );
+    REQUIRE( a.f == 0 );
+}
+
+TEST_CASE("Construct with values", "[construction]") {
+    Affine a(1, 2, 3, 4, 5, 6);
+    REQUIRE( a.a == 1 );
+    REQUIRE( a.b == 2 );
+    REQUIRE( a.c == 3 );
+    REQUIRE( a.d == 4 );
+    REQUIRE( a.e == 5 );
+    REQUIRE( a.f == 6 );
+}
+
+TEST_CASE("Construct from GDAL order", "[construction]") {
+    Affine a = Affine::from_gdal(3, 1, 2, 6, 4, 5);
+    REQUIRE( a.a == 1 );
+    REQUIRE( a.b == 2 );
+    REQUIRE( a.c == 3 );
+    REQUIRE( a.d == 4 );
+    REQUIRE( a.e == 5 );
+    REQUIRE( a.f == 6 );
+}
+
+TEST_CASE("Invert identity is identity", "[invert]") {
+    Affine(a);
+    Affine inverse = ~a;
+    REQUIRE( inverse.a == 1 );
+    REQUIRE( inverse.b == 0 );
+    REQUIRE( inverse.c == 0 );
+    REQUIRE( inverse.d == 0 );
+    REQUIRE( inverse.e == 1 );
+    REQUIRE( inverse.f == 0 );
+}
+
+TEST_CASE("Invert okay", "[invert]") {
+    Affine a(1, 2, 4, 1, 4, 2);
+    Affine inverse = ~a;
+    REQUIRE( inverse.a == Approx(2));
+    REQUIRE( inverse.b == Approx(-1));
+    REQUIRE( inverse.c == Approx(-6));
+    REQUIRE( inverse.d == Approx(-0.5));
+    REQUIRE( inverse.e == Approx(0.5));
+    REQUIRE( inverse.f == Approx(1));
+
+    Affine a_again = ~inverse;
+    REQUIRE( a_again.a == Approx(1));
+    REQUIRE( a_again.b == Approx(2));
+    REQUIRE( a_again.c == Approx(4));
+    REQUIRE( a_again.d == Approx(1));
+    REQUIRE( a_again.e == Approx(4));
+    REQUIRE( a_again.f == Approx(2));
+}
+
+TEST_CASE("Invert translation", "[invert]") {
+    double x = 2;
+    double y = 4;
+    Affine a(1, 0, x, 0, 1, y);
+    Affine inverse = ~a;
+    REQUIRE( inverse.a == Approx(1));
+    REQUIRE( inverse.b == Approx(0));
+    REQUIRE( inverse.c == Approx(-2));
+    REQUIRE( inverse.d == Approx(0));
+    REQUIRE( inverse.e == Approx(1));
+    REQUIRE( inverse.f == Approx(-4));
+}
+
+TEST_CASE("Invert scaling", "[invert]") {
+    double scale = 3;
+    Affine a(scale, 0, 0, 0, scale, 0);
+    Affine inverse = ~a;
+    REQUIRE( inverse.a == Approx(1/scale));
+    REQUIRE( inverse.b == Approx(0));
+    REQUIRE( inverse.c == Approx(0));
+    REQUIRE( inverse.d == Approx(0));
+    REQUIRE( inverse.e == Approx(1/scale));
+    REQUIRE( inverse.f == Approx(0));
+}
+
+TEST_CASE("Scale transform", "[transform]") {
+    double scale = 3;
+    Affine a(scale, 0, 0, 0, scale, 0);
+    geometry::Vec2<double> p(0.5, 0.5);
+    geometry::Vec2<double> expected(1.5, 1.5);
+    auto actual = a * p;
+    REQUIRE( actual.x == Approx(expected.x));
+    REQUIRE( actual.y == Approx(expected.y));
+    REQUIRE( actual == expected);
+}
+
+TEST_CASE("Translate transform", "[transform]") {
+    double x = 2;
+    double y = 4;
+    Affine a(1, 0, x, 0, 1, y);
+    geometry::Vec2<double> p(0.5, 0.5);
+    geometry::Vec2<double> expected(2.5, 4.5);
+    auto actual = a * p;
+    REQUIRE( actual.x == Approx(expected.x));
+    REQUIRE( actual.y == Approx(expected.y));
+    REQUIRE( actual == expected);
+}

--- a/tests/test_data/fake_raster.asc
+++ b/tests/test_data/fake_raster.asc
@@ -1,8 +1,0 @@
-ncols        2
-nrows        2
-xllcorner    0.0
-yllcorner    0.0
-cellsize     1.0
-NODATA_value  -9999
-0 0
-0 0


### PR DESCRIPTION
Closes #5 and #6

## Notes
- Affine is a struct not a class - so all members are public. We basically treat it as immutable once constructed, don't know if there's a better way to express this.
- Grid holds two transforms - the grid-to-world direction is provided by the usual metadata, world-to-grid is calculated as the inverse in the constructors, based on the assumption that we'll want to calculate the transform once and use it often.