### PR TITLE
Build intersections extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          python setup.py develop
+          pip install -e .
 
       - name: Lint with flake8
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,20 +4,24 @@ project(snail)
 set(CPP_SRC_DIR src/cpp)
 set(CPP_TESTS_DIR tests/cpp)
 
-add_subdirectory(${CPP_TESTS_DIR}/lib/Catch2)
-add_executable(run_tests
-  ${CPP_TESTS_DIR}/run_tests.cpp
-  ${CPP_TESTS_DIR}/tests_intersections.cpp
-  ${CPP_TESTS_DIR}/tests_transform.cpp
-  ${CPP_SRC_DIR}/find_intersections_linestring.cpp
-)
-target_include_directories(run_tests PUBLIC ${CPP_SRC_DIR})
-target_link_libraries(run_tests PRIVATE Catch2::Catch2)
+# "SKBUILD" is true if cmake is called from scikit-build, typically
+# building the wheel from pip. If this is the case, we don't build the
+# test executable.
+if (NOT SKBUILD)
+  add_subdirectory(${CPP_TESTS_DIR}/lib/Catch2)
+  add_executable(run_tests
+    ${CPP_TESTS_DIR}/run_tests.cpp
+    ${CPP_TESTS_DIR}/tests_intersections.cpp
+    ${CPP_TESTS_DIR}/tests_transform.cpp
+    ${CPP_SRC_DIR}/find_intersections_linestring.cpp
+    )
+  target_include_directories(run_tests PUBLIC ${CPP_SRC_DIR})
+  target_link_libraries(run_tests PRIVATE Catch2::Catch2)
+endif()
 
 add_subdirectory(pybind11)
 pybind11_add_module(intersections
   ${CPP_SRC_DIR}/intersections.cpp
   ${CPP_SRC_DIR}/find_intersections_linestring.cpp
 )
-
-  
+install(TARGETS intersections LIBRARY DESTINATION .)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "scikit-build", "cmake"]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'setuptools_scm'
     ],
     install_requires=[
-        'shapely'
+        'affine', 'numpy', 'geopandas', 'shapely', 'rasterio'
     ],
     extras_require={
         # eg:
@@ -58,7 +58,8 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            # eg: 'snail = snail.cli:main',
+            'snail_split = snail.cli:snail_split',
+            'snail_raster2split = snail.cli:snail_raster2split',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from glob import glob
 from os.path import basename, splitext
 
 from setuptools import find_packages
-from setuptools import setup
+from skbuild import setup
 
 
 def readme():
@@ -29,6 +29,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
+    cmake_install_dir="src/snail",
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/src/cpp/intersections.cpp
+++ b/src/cpp/intersections.cpp
@@ -49,6 +49,7 @@ std::vector<py::object> convert_cpp2py(std::vector<linestr> splits) {
   }
   return splits_py;
 }
+
 std::vector<py::object> split(py::object linestring_py, int nrows, int ncols,
                             std::vector<double> transform) {
   linestr linestring = convert_py2cpp(linestring_py);
@@ -61,8 +62,27 @@ std::vector<py::object> split(py::object linestring_py, int nrows, int ncols,
   return convert_cpp2py(splits);
 }
 
+std::tuple<int, int> get_cell_indices(py::object linestring, int nrows,
+                                      int ncols,
+                                      std::vector<double> transform) {
+  py::tuple bounds = linestring.attr("bounds");
+  double minx = (py::float_)bounds[0];
+  double miny = (py::float_)bounds[1];
+  double maxx = (py::float_)bounds[2];
+  double maxy = (py::float_)bounds[3];
+  geo::Vec2<double> midpoint =
+      geo::Vec2<double>((maxx + minx) * 0.5, (maxy + miny) * 0.5);
+
+  Affine affine(transform[0], transform[1], transform[2], transform[3],
+                transform[4], transform[5]);
+  Grid grid(ncols, nrows, affine);
+  geo::Vec2<int> cell = grid.cellIndices(midpoint);
+  return std::make_tuple(cell.x, cell.y);
+}
+
 PYBIND11_MODULE(intersections, m) {
   m.doc() = "pybind11 example plugin"; // optional module docstring
 
   m.def("split", &split, "A function");
+  m.def("get_cell_indices", &get_cell_indices, "Getting cell indices");
 }

--- a/src/cpp/transform.hpp
+++ b/src/cpp/transform.hpp
@@ -1,6 +1,8 @@
 #ifndef TRANSFORM_H
 #define TRANSFORM_H
 
+#include <vector>
+
 #include "exceptions.hpp"
 #include "geom.hpp"
 
@@ -27,6 +29,10 @@ struct Affine {
   /// Construct with six parameters, first two rows of 3x3 matrix
   Affine(double a, double b, double c, double d, double e, double f)
       : a{a}, b{b}, c{c}, d{d}, e{e}, f{f} {};
+
+  /// Same as above but construct from vector
+  Affine(std::vector<double> c)
+      : a{c[0]}, b{c[1]}, c{c[2]}, d{c[3]}, e{c[4]}, f{c[5]} {};
 
   /// Construct from GDALGeoTransform ordering of parameters
   /// see

--- a/src/snail/__init__.py
+++ b/src/snail/__init__.py
@@ -12,7 +12,7 @@ import pkg_resources
 try:
     __version__ = pkg_resources.get_distribution(__name__).version
 except pkg_resources.DistributionNotFound:
-    __version__ = 'unknown'
+    __version__ = "unknown"
 
 
 # Define what should be imported as * when a client writes::

--- a/src/snail/__main__.py
+++ b/src/snail/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -1,0 +1,61 @@
+import argparse
+
+import geopandas as gpd
+import rasterio
+
+from snail.snail_intersections import split, raster2split
+
+
+def parse_arguments(arguments):
+    parser = argparse.ArgumentParser(description="the parser")
+    parser.add_argument(
+        "-r",
+        "--raster",
+        type=str,
+        help="The path to the raster data file",
+        required=True,
+    )
+    parser.add_argument(
+        "-v",
+        "--vector",
+        type=str,
+        help="The path to the vector data file",
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="The path to the output vector data file",
+        required=True,
+    )
+    parser.add_argument(
+        "--bands",
+        type=int,
+        help="Indices of raster bands to be read",
+        nargs="+",
+        required=False,
+    )
+
+    args = parser.parse_args(arguments)
+    return args
+
+
+def snail_split(arguments=None):
+    args = parse_arguments(arguments)
+
+    raster_data = rasterio.open(args.raster)
+    vector_data = gpd.read_file(args.vector)
+
+    new_gdf = split(vector_data, raster_data)
+    new_gdf.to_file(args.output)
+
+
+def snail_raster2split(arguments=None):
+    args = parse_arguments(arguments)
+
+    raster_data = rasterio.open(args.raster)
+    vector_data = gpd.read_file(args.vector)
+
+    new_gdf = raster2split(vector_data, raster_data, args.bands)
+    new_gdf.to_file(args.output)

--- a/src/snail/snail_intersections.py
+++ b/src/snail/snail_intersections.py
@@ -1,0 +1,39 @@
+import geopandas as gpd
+
+from snail.intersections import split as split_one_geom
+from snail.intersections import get_cell_indices
+
+
+def split(vector_data, raster_data):
+    all_splits = []
+    all_idx = []
+    for idx, linestring in zip(vector_data.index, vector_data["geometry"]):
+        splits = split_one_geom(
+            linestring,
+            raster_data.width,
+            raster_data.height,
+            list(raster_data.transform),
+        )
+        all_splits.extend(splits)
+        all_idx.extend([idx] * len(splits))
+
+    return gpd.GeoDataFrame({"line index": all_idx, "geometry": all_splits})
+
+
+def raster2split(vector_data, raster_data, bands=[1], inplace=False):
+    returned_gdf = vector_data.copy() if inplace else vector_data
+    for band in bands:
+        band_data = raster_data.read(band)
+        geom_raster_values = []
+        for split in vector_data["geometry"]:
+            cell_x, cell_y = get_cell_indices(
+                split,
+                raster_data.width,
+                raster_data.height,
+                list(raster_data.transform),
+            )
+            geom_raster_values.append(band_data[cell_x, cell_y])
+        returned_gdf.insert(
+            len(vector_data.columns), f"band{band}", geom_raster_values
+        )
+    return returned_gdf

--- a/tests/test_intersections.py
+++ b/tests/test_intersections.py
@@ -6,6 +6,11 @@ from snail import intersections
 
 
 class TestIntersections(unittest.TestCase):
+    def setUp(self):
+        self.nrows = 2
+        self.ncols = 2
+        self.transform = [1, 0, 0, 0, 1, 0]
+
     def test_linestring_splitting(self):
         test_linestrings = [
             LineString([(0.5, 0.5), (0.75, 0.5), (1.5, 0.5), (1.5, 1.5)]),
@@ -24,14 +29,11 @@ class TestIntersections(unittest.TestCase):
             ],
         ]
 
-        nrows = 2
-        ncols = 2
-        transform = [1, 0, 0, 0, 1, 0]
         for i, test_data in enumerate(zip(test_linestrings, expected)):
             test_linestring, expected_splits = test_data
             with self.subTest(i=i):
                 splits = intersections.split(
-                    test_linestring, nrows, ncols, transform
+                    test_linestring, self.nrows, self.ncols, self.transform
                 )
                 self.assertTrue(
                     [
@@ -41,3 +43,17 @@ class TestIntersections(unittest.TestCase):
                         )
                     ]
                 )
+
+    def test_get_cell_indices(self):
+        test_linestrings = [
+            LineString([(0.25, 1.25), (0.5, 1.5), (0.5, 1.75)]),
+            LineString([(1.25, 1.25), (1.5, 1.5), (1.5, 1.75)]),
+        ]
+        expected_cell_indices = [(0, 1), (1, 1)]
+
+        for i, test_linestring in enumerate(test_linestrings):
+            with self.subTest(i=i):
+                cell_indices = intersections.get_cell_indices(
+                    test_linestring, self.nrows, self.ncols, self.transform
+                )
+                self.assertEqual(cell_indices, expected_cell_indices[i])

--- a/tests/test_intersections.py
+++ b/tests/test_intersections.py
@@ -2,11 +2,7 @@ import unittest
 
 from shapely.geometry import LineString
 
-import sys
-
-# TODO: Update setup script to install extension module
-sys.path.append("build_python")
-import intersections
+from snail import intersections
 
 
 class TestIntersections(unittest.TestCase):

--- a/tests/test_snail_intersections.py
+++ b/tests/test_snail_intersections.py
@@ -1,0 +1,98 @@
+import unittest
+
+from affine import Affine
+import numpy as np
+from numpy.testing import assert_array_equal, assert_array_almost_equal
+import geopandas as gpd
+from rasterio.io import MemoryFile
+from shapely.geometry import LineString
+
+from snail.snail_intersections import split, raster2split
+
+
+def make_raster_data():
+    data = np.random.randn(2, 2)
+    memfile = MemoryFile()
+    new_dataset = memfile.open(
+        driver="GTiff",
+        width=data.shape[1],
+        height=data.shape[0],
+        count=1,
+        crs="+proj=latlong",
+        transform=Affine.identity(),
+        dtype=data.dtype,
+    )
+    new_dataset.write(data, 1)
+    return new_dataset
+
+
+def make_vector_data():
+    test_linestrings = [
+        LineString([(0.5, 0.5), (0.75, 0.5), (1.5, 0.5), (1.5, 1.5)]),
+        LineString([(0.5, 0.5), (0.75, 0.5), (1.5, 1.5)]),
+    ]
+    gdf = gpd.GeoDataFrame(
+        {"col1": ["name1", "name2"], "geometry": test_linestrings}
+    )
+    return gdf
+
+
+def get_expected_gdf():
+    expected_splits = [
+        LineString([(0.5, 0.5), (0.75, 0.5), (1.0, 0.5)]),
+        LineString([(1.0, 0.5), (1.5, 0.5), (1.5, 1.0)]),
+        LineString([(1.5, 1.0), (1.5, 1.5)]),
+    ] + [
+        LineString([(0.5, 0.5), (0.75, 0.5), (1.0, 0.8333)]),
+        LineString([(1.0, 0.8333), (1.125, 1.0)]),
+        LineString([(1.125, 1.0), (1.5, 1.5)]),
+    ]
+    expected_idx = [0] * 3 + [1] * 3
+    expected_gdf = gpd.GeoDataFrame(
+        {"line index": expected_idx, "geometry": expected_splits}
+    )
+    return expected_gdf
+
+
+class TestSnailIntersections(unittest.TestCase):
+    def setUp(self):
+        self.raster_dataset = make_raster_data()
+
+    def tearDown(self):
+        self.raster_dataset.close()
+
+    def test_split(self):
+        vector_data = make_vector_data()
+        gdf = split(vector_data, self.raster_dataset)
+        expected_gdf = get_expected_gdf()
+
+        # Assertions
+
+        # Ideally we'd like to use geopandas.assert_geodataframe_equal to
+        # to compare both expected and actual geodfs, but this function offers
+        # little control over tolerance. When using option "check_less_precise",
+        # it used GeoSeries.geom_almost_equals under the hood, which has an kwarg
+        # "decimal". But assert_geodataframe_equal does not recognise kwarg "decimal".
+        self.assertTrue(
+            list(
+                gdf["geometry"]
+                .geom_almost_equals(expected_gdf["geometry"], decimal=3)
+                .values
+            )
+        )
+        assert_array_equal(
+            gdf["line index"].values, expected_gdf["line index"].values
+        )
+
+    def test_raster2split(self):
+        vector_data = get_expected_gdf()
+
+        output_gdf = raster2split(vector_data, self.raster_dataset, bands=[1])
+
+        # Expected raster values are points (0,1), (1,0) and (1,1) of the grid
+        data_array_indices = ([0, 1, 1], [0, 0, 1])
+        raster_data = self.raster_dataset.read(1)
+        expected_raster_values = np.tile(raster_data[data_array_indices], 2)
+        assert_array_almost_equal(
+            output_gdf["band1"].values, expected_raster_values
+        )


### PR DESCRIPTION
This adds some infrastruture to build the `intersections` extension into a Python wheel. This uses scikit-build which allows to easily interface with CMake. 

scikit-build is installed at build-time according to `pyproject.toml`.

`pip install .` builds the extension using CMake, bundles it inside a wheel, and installs it in the current environment.
Eventually, the `intersections` module ends up inside the `snail/` package alongside the other modules:

```python
from snail.intersections import split
```