### PR TITLE
Add a command line interface to intersections kernel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         'setuptools_scm'
     ],
     install_requires=[
-        'shapely'
+        'affine', 'numpy', 'geopandas', 'shapely', 'rasterio'
     ],
     extras_require={
         # eg:

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'snail_split = snail.cli:main',
+            'snail_split = snail.cli:snail_split',
+            'snail_raster2split = snail.cli:snail_raster2split',
         ]
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            # eg: 'snail = snail.cli:main',
+            'snail_split = snail.cli:main',
         ]
     },
 )

--- a/src/cpp/intersections.cpp
+++ b/src/cpp/intersections.cpp
@@ -49,6 +49,7 @@ std::vector<py::object> convert_cpp2py(std::vector<linestr> splits) {
   }
   return splits_py;
 }
+
 std::vector<py::object> split(py::object linestring_py, int nrows, int ncols,
                             std::vector<double> transform) {
   linestr linestring = convert_py2cpp(linestring_py);
@@ -61,8 +62,27 @@ std::vector<py::object> split(py::object linestring_py, int nrows, int ncols,
   return convert_cpp2py(splits);
 }
 
+std::tuple<int, int> get_cell_indices(py::object linestring, int nrows,
+                                      int ncols,
+                                      std::vector<double> transform) {
+  py::tuple bounds = linestring.attr("bounds");
+  double minx = (py::float_)bounds[0];
+  double miny = (py::float_)bounds[1];
+  double maxx = (py::float_)bounds[2];
+  double maxy = (py::float_)bounds[3];
+  geo::Vec2<double> midpoint =
+      geo::Vec2<double>((maxx + minx) * 0.5, (maxy + miny) * 0.5);
+
+  Affine affine(transform[0], transform[1], transform[2], transform[3],
+                transform[4], transform[5]);
+  Grid grid(ncols, nrows, affine);
+  geo::Vec2<int> cell = grid.cellIndices(midpoint);
+  return std::make_tuple(cell.x, cell.y);
+}
+
 PYBIND11_MODULE(intersections, m) {
   m.doc() = "pybind11 example plugin"; // optional module docstring
 
   m.def("split", &split, "A function");
+  m.def("get_cell_indices", &get_cell_indices, "Getting cell indices");
 }

--- a/src/cpp/transform.hpp
+++ b/src/cpp/transform.hpp
@@ -1,6 +1,8 @@
 #ifndef TRANSFORM_H
 #define TRANSFORM_H
 
+#include <vector>
+
 #include "exceptions.hpp"
 #include "geom.hpp"
 
@@ -27,6 +29,10 @@ struct Affine {
   /// Construct with six parameters, first two rows of 3x3 matrix
   Affine(double a, double b, double c, double d, double e, double f)
       : a{a}, b{b}, c{c}, d{d}, e{e}, f{f} {};
+
+  /// Same as above but construct from vector
+  Affine(std::vector<double> c)
+      : a{c[0]}, b{c[1]}, c{c[2]}, d{c[3]}, e{c[4]}, f{c[5]} {};
 
   /// Construct from GDALGeoTransform ordering of parameters
   /// see

--- a/src/snail/__init__.py
+++ b/src/snail/__init__.py
@@ -12,7 +12,7 @@ import pkg_resources
 try:
     __version__ = pkg_resources.get_distribution(__name__).version
 except pkg_resources.DistributionNotFound:
-    __version__ = 'unknown'
+    __version__ = "unknown"
 
 
 # Define what should be imported as * when a client writes::

--- a/src/snail/__main__.py
+++ b/src/snail/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -1,5 +1,7 @@
 import argparse
 
+import geopandas as gpd
+import rasterio
 
 def parse_arguments():
     parser = argparse.ArgumentParser(description="the parser")
@@ -32,6 +34,8 @@ def parse_arguments():
 def main(arguments=None):
     args = parse_arguments()
 
+    raster_data = rasterio.open(args.raster)
+    vector_data = gpd.read_file(args.vector)
     print("Working with:")
     print(f"  Raster dataset: {args.raster}")
     print(f"  Vector dataset: {args.vector}")

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -3,7 +3,7 @@ import argparse
 import geopandas as gpd
 import rasterio
 
-from snail.intersections import split
+from snail.snail_intersections import split, raster2split
 
 
 def parse_arguments(arguments):
@@ -29,27 +29,33 @@ def parse_arguments(arguments):
         help="The path to the output vector data file",
         required=True,
     )
+    parser.add_argument(
+        "--bands",
+        type=int,
+        help="Indices of raster bands to be read",
+        nargs="+",
+        required=False,
+    )
 
     args = parser.parse_args(arguments)
     return args
 
 
-def main(arguments=None):
+def snail_split(arguments=None):
     args = parse_arguments(arguments)
 
     raster_data = rasterio.open(args.raster)
     vector_data = gpd.read_file(args.vector)
 
-    all_splits = []
-    all_idx = []
-    for idx, linestring in zip(vector_data.index, vector_data["geometry"]):
-        splits = split(
-            linestring,
-            raster_data.width,
-            raster_data.height,
-            list(raster_data.transform),
-        )
-        all_splits.extend(splits)
-        all_idx.extend([idx] * len(splits))
-    new_gdf = gpd.GeoDataFrame({"line index": all_idx, "geometry": all_splits})
+    new_gdf = split(vector_data, raster_data)
+    new_gdf.to_file(args.output)
+
+
+def snail_raster2split(arguments=None):
+    args = parse_arguments(arguments)
+
+    raster_data = rasterio.open(args.raster)
+    vector_data = gpd.read_file(args.vector)
+
+    new_gdf = raster2split(vector_data, raster_data, args.bands)
     new_gdf.to_file(args.output)

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -3,7 +3,8 @@ import argparse
 import geopandas as gpd
 import rasterio
 
-def parse_arguments():
+
+def parse_arguments(arguments):
     parser = argparse.ArgumentParser(description="the parser")
     parser.add_argument(
         "-r",
@@ -27,12 +28,12 @@ def parse_arguments():
         required=True,
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(arguments)
     return args
 
 
 def main(arguments=None):
-    args = parse_arguments()
+    args = parse_arguments(arguments)
 
     raster_data = rasterio.open(args.raster)
     vector_data = gpd.read_file(args.vector)

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -1,0 +1,2 @@
+def main():
+    print("Hello from the main function")

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -40,14 +40,16 @@ def main(arguments=None):
     raster_data = rasterio.open(args.raster)
     vector_data = gpd.read_file(args.vector)
 
-    for linestring in vector_data["geometry"].values:
+    all_splits = []
+    all_idx = []
+    for idx, linestring in zip(vector_data.index, vector_data["geometry"]):
         splits = split(
             linestring,
             raster_data.width,
             raster_data.height,
             list(raster_data.transform),
         )
-    print("Working with:")
-    print(f"  Raster dataset: {args.raster}")
-    print(f"  Vector dataset: {args.vector}")
-    print(f"  Output vector dataset: {args.output}")
+        all_splits.extend(splits)
+        all_idx.extend([idx] * len(splits))
+    new_gdf = gpd.GeoDataFrame({"line index": all_idx, "geometry": all_splits})
+    new_gdf.to_file(args.output)

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -1,2 +1,38 @@
-def main():
-    print("Hello from the main function")
+import argparse
+
+
+def parse_arguments():
+    parser = argparse.ArgumentParser(description="the parser")
+    parser.add_argument(
+        "-r",
+        "--raster",
+        type=str,
+        help="The path to the raster data file",
+        required=True,
+    )
+    parser.add_argument(
+        "-v",
+        "--vector",
+        type=str,
+        help="The path to the vector data file",
+        required=True,
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="The path to the output vector data file",
+        required=True,
+    )
+
+    args = parser.parse_args()
+    return args
+
+
+def main(arguments=None):
+    args = parse_arguments()
+
+    print("Working with:")
+    print(f"  Raster dataset: {args.raster}")
+    print(f"  Vector dataset: {args.vector}")
+    print(f"  Output vector dataset: {args.output}")

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -3,6 +3,8 @@ import argparse
 import geopandas as gpd
 import rasterio
 
+from snail.intersections import split
+
 
 def parse_arguments(arguments):
     parser = argparse.ArgumentParser(description="the parser")
@@ -37,6 +39,14 @@ def main(arguments=None):
 
     raster_data = rasterio.open(args.raster)
     vector_data = gpd.read_file(args.vector)
+
+    for linestring in vector_data["geometry"].values:
+        splits = split(
+            linestring,
+            raster_data.width,
+            raster_data.height,
+            list(raster_data.transform),
+        )
     print("Working with:")
     print(f"  Raster dataset: {args.raster}")
     print(f"  Vector dataset: {args.vector}")

--- a/src/snail/snail_intersections.py
+++ b/src/snail/snail_intersections.py
@@ -1,0 +1,39 @@
+import geopandas as gpd
+
+from snail.intersections import split as split_one_geom
+from snail.intersections import get_cell_indices
+
+
+def split(vector_data, raster_data):
+    all_splits = []
+    all_idx = []
+    for idx, linestring in zip(vector_data.index, vector_data["geometry"]):
+        splits = split_one_geom(
+            linestring,
+            raster_data.width,
+            raster_data.height,
+            list(raster_data.transform),
+        )
+        all_splits.extend(splits)
+        all_idx.extend([idx] * len(splits))
+
+    return gpd.GeoDataFrame({"line index": all_idx, "geometry": all_splits})
+
+
+def raster2split(vector_data, raster_data, bands=[1], inplace=False):
+    returned_gdf = vector_data.copy() if inplace else vector_data
+    for band in bands:
+        band_data = raster_data.read(band)
+        geom_raster_values = []
+        for split in vector_data["geometry"]:
+            cell_x, cell_y = get_cell_indices(
+                split,
+                raster_data.width,
+                raster_data.height,
+                list(raster_data.transform),
+            )
+            geom_raster_values.append(band_data[cell_x, cell_y])
+        returned_gdf.insert(
+            len(vector_data.columns), f"band{band}", geom_raster_values
+        )
+    return returned_gdf

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,29 +4,39 @@ import rasterio
 from affine import Affine
 import numpy
 from shapely.geometry import LineString
+import geopandas as gpd
 
 
 def make_raster_data():
     data = numpy.random.randn(2, 2)
+    raster_data = "/tmp/test_raster_data.tif"
     new_dataset = rasterio.open(
-        '/tmp/new.tif',
-        'w',
-        driver='GTiff',
+        raster_data,
+        "w",
+        driver="GTiff",
         height=data.shape[0],
         width=data.shape[1],
         count=1,
         dtype=data.dtype,
-        crs='+proj=latlong',
-        transform=Affine.identity()
+        crs="+proj=latlong",
+        transform=Affine.identity(),
     )
     new_dataset.write(data, 1)
     new_dataset.close()
+    return raster_data
 
 
 def make_vector_data():
-    pass
+    linestring = LineString([(0.5, 0.5), (0.75, 0.5), (1.5, 1.5)])
+    gdf = gpd.GeoDataFrame({"col1": ["name1"], "geometry": [linestring]})
+    vector_data = "/tmp/test_vector_data.gpkg"
+    gdf.to_file(vector_data)
+    return vector_data
+
 
 class TestCli(unittest.TestCase):
     def test_cli(self):
         raster_data = make_raster_data()
         vector_data = make_vector_data()
+
+        self.assertTrue(True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,8 @@ import numpy
 from shapely.geometry import LineString
 import geopandas as gpd
 
+import snail.cli
+
 
 def make_raster_data():
     data = numpy.random.randn(2, 2)
@@ -38,5 +40,14 @@ class TestCli(unittest.TestCase):
     def test_cli(self):
         raster_data = make_raster_data()
         vector_data = make_vector_data()
-
+        output_data = "/tmp/test_output.gpkg"
+        args = [
+            "--raster",
+            raster_data,
+            "--vector",
+            vector_data,
+            "--output",
+            output_data,
+        ]
+        snail.cli.main(args)
         self.assertTrue(True)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,13 +2,12 @@ import os
 import tempfile
 import unittest
 
-import rasterio
 from affine import Affine
 import numpy
-from shapely.geometry import LineString
-import geopandas as gpd
-from geopandas.testing import assert_geodataframe_equal
 from numpy.testing import assert_array_almost_equal
+import geopandas as gpd
+import rasterio
+from shapely.geometry import LineString
 
 import snail.cli
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import unittest
 
 from affine import Affine
 import numpy
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_equal
 import geopandas as gpd
 import rasterio
 from shapely.geometry import LineString
@@ -93,7 +93,7 @@ class TestCli(unittest.TestCase):
                 .values
             )
         )
-        assert_array_almost_equal(
+        assert_array_equal(
             gdf["line index"].values, expected_gdf["line index"].values
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,32 @@
+import unittest
+
+import rasterio
+from affine import Affine
+import numpy
+from shapely.geometry import LineString
+
+
+def make_raster_data():
+    data = numpy.random.randn(2, 2)
+    new_dataset = rasterio.open(
+        '/tmp/new.tif',
+        'w',
+        driver='GTiff',
+        height=data.shape[0],
+        width=data.shape[1],
+        count=1,
+        dtype=data.dtype,
+        crs='+proj=latlong',
+        transform=Affine.identity()
+    )
+    new_dataset.write(data, 1)
+    new_dataset.close()
+
+
+def make_vector_data():
+    pass
+
+class TestCli(unittest.TestCase):
+    def test_cli(self):
+        raster_data = make_raster_data()
+        vector_data = make_vector_data()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,23 @@ def make_vector_data(filename):
     gdf.to_file(filename)
 
 
+def get_expected_gdf():
+    expected_splits = [
+        LineString([(0.5, 0.5), (0.75, 0.5), (1.0, 0.5)]),
+        LineString([(1.0, 0.5), (1.5, 0.5), (1.5, 1.0)]),
+        LineString([(1.5, 1.0), (1.5, 1.5)]),
+    ] + [
+        LineString([(0.5, 0.5), (0.75, 0.5), (1.0, 0.8333)]),
+        LineString([(1.0, 0.8333), (1.125, 1.0)]),
+        LineString([(1.125, 1.0), (1.5, 1.5)]),
+    ]
+    expected_idx = [0] * 3 + [1] * 3
+    expected_gdf = gpd.GeoDataFrame(
+        {"line index": expected_idx, "geometry": expected_splits}
+    )
+    return expected_gdf
+
+
 class TestCli(unittest.TestCase):
     def test_cli(self):
         tmp_dir = tempfile.TemporaryDirectory()
@@ -61,19 +78,7 @@ class TestCli(unittest.TestCase):
         snail.cli.main(args)
 
         gdf = gpd.read_file(output_file)
-        expected_splits = [
-            LineString([(0.5, 0.5), (0.75, 0.5), (1.0, 0.5)]),
-            LineString([(1.0, 0.5), (1.5, 0.5), (1.5, 1.0)]),
-            LineString([(1.5, 1.0), (1.5, 1.5)]),
-        ] + [
-            LineString([(0.5, 0.5), (0.75, 0.5), (1.0, 0.8333)]),
-            LineString([(1.0, 0.8333), (1.125, 1.0)]),
-            LineString([(1.125, 1.0), (1.5, 1.5)]),
-        ]
-        expected_idx = [0] * 3 + [1] * 3
-        expected_gdf = gpd.GeoDataFrame(
-            {"line index": expected_idx, "geometry": expected_splits}
-        )
+        expected_gdf = get_expected_gdf()
 
         # Assertions
 

--- a/tests/test_intersections.py
+++ b/tests/test_intersections.py
@@ -6,6 +6,11 @@ from snail import intersections
 
 
 class TestIntersections(unittest.TestCase):
+    def setUp(self):
+        self.nrows = 2
+        self.ncols = 2
+        self.transform = [1, 0, 0, 0, 1, 0]
+
     def test_linestring_splitting(self):
         test_linestrings = [
             LineString([(0.5, 0.5), (0.75, 0.5), (1.5, 0.5), (1.5, 1.5)]),
@@ -24,14 +29,11 @@ class TestIntersections(unittest.TestCase):
             ],
         ]
 
-        nrows = 2
-        ncols = 2
-        transform = [1, 0, 0, 0, 1, 0]
         for i, test_data in enumerate(zip(test_linestrings, expected)):
             test_linestring, expected_splits = test_data
             with self.subTest(i=i):
                 splits = intersections.split(
-                    test_linestring, nrows, ncols, transform
+                    test_linestring, self.nrows, self.ncols, self.transform
                 )
                 self.assertTrue(
                     [
@@ -41,3 +43,17 @@ class TestIntersections(unittest.TestCase):
                         )
                     ]
                 )
+
+    def test_get_cell_indices(self):
+        test_linestrings = [
+            LineString([(0.25, 1.25), (0.5, 1.5), (0.5, 1.75)]),
+            LineString([(1.25, 1.25), (1.5, 1.5), (1.5, 1.75)]),
+        ]
+        expected_cell_indices = [(0, 1), (1, 1)]
+
+        for i, test_linestring in enumerate(test_linestrings):
+            with self.subTest(i=i):
+                cell_indices = intersections.get_cell_indices(
+                    test_linestring, self.nrows, self.ncols, self.transform
+                )
+                self.assertEqual(cell_indices, expected_cell_indices[i])

--- a/tests/test_snail_intersections.py
+++ b/tests/test_snail_intersections.py
@@ -1,41 +1,40 @@
-import os
-import tempfile
 import unittest
 
 from affine import Affine
-import numpy
-from numpy.testing import assert_array_equal
+import numpy as np
+from numpy.testing import assert_array_equal, assert_array_almost_equal
 import geopandas as gpd
-import rasterio
+from rasterio.io import MemoryFile
 from shapely.geometry import LineString
 
-import snail.cli
+from snail.snail_intersections import split, raster2split
 
 
-def make_raster_data(filename):
-    data = numpy.random.randn(2, 2)
-    new_dataset = rasterio.open(
-        filename,
-        "w",
+def make_raster_data():
+    data = np.random.randn(2, 2)
+    memfile = MemoryFile()
+    new_dataset = memfile.open(
         driver="GTiff",
-        height=data.shape[0],
         width=data.shape[1],
+        height=data.shape[0],
         count=1,
-        dtype=data.dtype,
         crs="+proj=latlong",
         transform=Affine.identity(),
+        dtype=data.dtype,
     )
     new_dataset.write(data, 1)
-    new_dataset.close()
+    return new_dataset
 
 
-def make_vector_data(filename):
+def make_vector_data():
     test_linestrings = [
         LineString([(0.5, 0.5), (0.75, 0.5), (1.5, 0.5), (1.5, 1.5)]),
         LineString([(0.5, 0.5), (0.75, 0.5), (1.5, 1.5)]),
     ]
-    gdf = gpd.GeoDataFrame({"col1": ["name1", "name2"], "geometry": test_linestrings})
-    gdf.to_file(filename)
+    gdf = gpd.GeoDataFrame(
+        {"col1": ["name1", "name2"], "geometry": test_linestrings}
+    )
+    return gdf
 
 
 def get_expected_gdf():
@@ -55,28 +54,16 @@ def get_expected_gdf():
     return expected_gdf
 
 
-class TestCli(unittest.TestCase):
-    def test_cli(self):
-        tmp_dir = tempfile.TemporaryDirectory()
-        raster_file = os.path.join(tmp_dir.name, "test_raster.tif")
-        vector_file = os.path.join(tmp_dir.name, "test_vector.gpkg")
-        output_file = os.path.join(tmp_dir.name, "test_output.gpkg")
+class TestSnailIntersections(unittest.TestCase):
+    def setUp(self):
+        self.raster_dataset = make_raster_data()
 
-        make_raster_data(raster_file)
-        make_vector_data(vector_file)
+    def tearDown(self):
+        self.raster_dataset.close()
 
-        args = [
-            "--raster",
-            raster_file,
-            "--vector",
-            vector_file,
-            "--output",
-            output_file,
-        ]
-
-        snail.cli.main(args)
-
-        gdf = gpd.read_file(output_file)
+    def test_split(self):
+        vector_data = make_vector_data()
+        gdf = split(vector_data, self.raster_dataset)
         expected_gdf = get_expected_gdf()
 
         # Assertions
@@ -97,4 +84,15 @@ class TestCli(unittest.TestCase):
             gdf["line index"].values, expected_gdf["line index"].values
         )
 
-        tmp_dir.cleanup()
+    def test_raster2split(self):
+        vector_data = get_expected_gdf()
+
+        output_gdf = raster2split(vector_data, self.raster_dataset, bands=[1])
+
+        # Expected raster values are points (0,1), (1,0) and (1,1) of the grid
+        data_array_indices = ([0, 1, 1], [0, 0, 1])
+        raster_data = self.raster_dataset.read(1)
+        expected_raster_values = np.tile(raster_data[data_array_indices], 2)
+        assert_array_almost_equal(
+            output_gdf["band1"].values, expected_raster_values
+        )


### PR DESCRIPTION
This implements a command `snail_split` that takes raster data, vector data and output vector data files as arguments and runs the intersections kernel. This is close to what #8 describes.

Raster data is read using `rasterio` and vector data is read and written using `geopandas`.
The ouput vector data is written as a geodataframe for which the geometry column is the lists of splits for each of the original linestrings. In addition this dataframe has a column "line index" that is the index of the original (non-split) linestring in the original geodataframe.

### Example
We start with a geodataframe with 2 linestrings that we want to split according the intersections with some raster data.

```python
>>> print(original_gdf)
    col1                                           geometry
0  name1  LINESTRING (0.50000 0.50000, 0.75000 0.50000, ...
1  name2  LINESTRING (0.50000 0.50000, 0.75000 0.50000, ...
```
After calling the `intersections.split` function, the output vector data looks like
```python
>>> print(output_gdf)
   line index                                           geometry
0           0  LINESTRING (0.50000 0.50000, 0.75000 0.50000, ...
1           0  LINESTRING (1.00000 0.50000, 1.50000 0.50000, ...
2           0      LINESTRING (1.50000 1.00000, 1.50000 1.50000)
3           1  LINESTRING (0.50000 0.50000, 0.75000 0.50000, ...
4           1      LINESTRING (1.00000 0.83330, 1.12500 1.00000)
5           1      LINESTRING (1.12500 1.00000, 1.50000 1.50000)
```

This tells us that both linestrings in `original_gdf` were split into 3 linestrings each. According to the `line index` column, the first three correspond to the first linestring in the original dataset, and the remaining three correspond to the second linestring.