### PR TITLE
Python prototype for polygon/raster intersection

### DIFF
--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -84,25 +84,21 @@ def split_along_gridlines(
     return gridline_splits
 
 
-inner_grid_lines = []
-
-split_along_gridlines(
+horiz_splits = split_along_gridlines(
     exterior_splits,
     min_idx=int(miny) + 1,
     max_idx=int(maxy),
     direction="horizontal",
 )
 
-for x in range(int(minx) + 1, int(maxx) + 1):
-    p = [coord for coord in inter_points.coords if coord[0] == x]
-    line2s = list(zip(p, p[1:]))[::2]
-    for line2 in line2s:
-        local_splits = split_one_geom(
-            LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0]
-        )
-        inner_grid_lines.extend(local_splits)
+vert_splits = split_along_gridlines(
+    exterior_splits,
+    min_idx=int(minx) + 1,
+    max_idx=int(maxx),
+    direction="vertical",
+)
 
-polygons = list(polygonize(splits + inner_grid_lines))
+polygons = list(polygonize(exterior_splits + horiz_splits + vert_splits))
 
 ax = plt.subplot()
 for p in polygons:

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -71,14 +71,17 @@ def split_along_gridlines(
                 get_crossings(exterior_splits),
             )
         )
-        gridline_segments = list(
-            zip(crossings_on_gridline, crossings_on_gridline[1:])
-        )
+        gridline_segments = [
+            LineString(coord_pair)
+            for coord_pair in zip(
+                crossings_on_gridline, crossings_on_gridline[1:]
+            )
+        ]
         # Only every other gridline segments (between two consecutive
         # crossings) is contained in the polygon
         for gridline_segment in gridline_segments[::2]:
             splits = split_one_geom(
-                LineString(gridline_segment), nrows, ncols, [1, 0, 0, 0, 1, 0]
+                gridline_segment, nrows, ncols, [1, 0, 0, 0, 1, 0]
             )
             gridline_splits.extend(splits)
     return gridline_splits

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -30,7 +30,7 @@ def plot_line(ax, ob, color=BLUE, zorder=1, linewidth=3, alpha=1):
 
 nrows = 5
 ncols = 3
-points = [(1.5, 0.5), (2.5, 1.5), (2.5, 3.5), (1.5, 3.25), (0.5, 3.5), (0.5, 1.5)]
+points = [(1.5, 0.25), (2.5, 1.5), (2.5, 3.5), (1.5, 2.25), (0.5, 3.5), (0.5, 1.5)]
 ring = orient(Polygon(points), -1)
 splits = split_one_geom(ring.exterior, nrows, ncols, [1, 0, 0, 0, 1, 0])
 

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -70,15 +70,6 @@ for x in range(int(minx) + 1, int(maxx) + 1):
 polygons = list(polygonize(splits + inner_grid_lines))
 
 ax = plt.subplot()
-plot_coords(ax, ring.exterior)
-plot_line(ax, ring.exterior)
-for i in range(nrows):
-    plt.axhline(i, 0, ncols - 1)
-for i in range(ncols):
-    plt.axvline(i, 0, nrows - 1)
-plot_coords(ax, inter_points, color=RED)
-
-for line in inner_grid_lines:
-    plot_line(ax, line, color=GREEN)
-
+for p in polygons:
+    plot_line(ax, p.exterior)
 plt.show()

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -1,0 +1,34 @@
+from shapely.geometry.polygon import LinearRing
+import matplotlib.pyplot as plt
+
+from snail.intersections import split as split_one_geom
+
+BLUE = "#6699cc"
+GRAY = "#999999"
+
+
+def plot_coords(ax, ob, color=GRAY, zorder=1, alpha=1):
+    x, y = ob.xy
+    ax.plot(x, y, "o", color=color, zorder=zorder, alpha=alpha)
+
+
+def plot_line(ax, ob, color=BLUE, zorder=1, linewidth=3, alpha=1):
+    x, y = ob.xy
+    ax.plot(
+        x,
+        y,
+        color=color,
+        linewidth=linewidth,
+        solid_capstyle="round",
+        zorder=zorder,
+        alpha=alpha,
+    )
+
+
+ax = plt.subplot()
+points = [(2.5, 1.5), (3.5, 2), (3.5, 5), (2.5, 4.5), (1.5, 5), (1.5, 2)]
+ring = LinearRing(points)
+plot_coords(ax, ring)
+plot_line(ax, ring)
+plt.grid(True)
+plt.show()

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -71,7 +71,7 @@ points = [
     (0.5, 3.5),
     (0.5, 1.5),
 ]
-ring = orient(Polygon(points), -1)
+ring = orient(Polygon(points), 1)
 minx, miny, maxx, maxy = ring.bounds
 
 exterior_splits = split_one_geom(

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -48,15 +48,22 @@ minx = b_box[0]
 
 inner_grid_lines = []
 for y in range(int(miny) + 1, int(maxy) + 1):
-    p = list(
+    # Split horizontal grid lines inside polygon according to
+    # intersections with vertical grid lines.
+    crossings_on_gridline = list(
         filter(lambda coord: coord[1] == y, get_crossings(splits))
     )
-    line2s = list(zip(p, p[1:]))[::2]
-    for line2 in line2s:
-        local_splits = split_one_geom(
-            LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0]
+    gridline_segments = list(
+        zip(crossings_on_gridline, crossings_on_gridline[1:])
+    )
+    # Only every other gridline segments (between two consecutive
+    # crossings) is contained in the polygon
+    for line2 in gridline_segments[::2]:
+        inner_grid_lines.extend(
+            split_one_geom(
+                LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0]
+            )
         )
-        inner_grid_lines.extend(local_splits)
 
 for x in range(int(minx) + 1, int(maxx) + 1):
     p = [coord for coord in inter_points.coords if coord[0] == x]

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -1,10 +1,13 @@
 from shapely.geometry.polygon import LinearRing
+from shapely.geometry import LineString
+
 import matplotlib.pyplot as plt
 
 from snail.intersections import split as split_one_geom
 
 BLUE = "#6699cc"
 GRAY = "#999999"
+RED = '#ff3333'
 
 
 def plot_coords(ax, ob, color=GRAY, zorder=1, alpha=1):
@@ -25,10 +28,23 @@ def plot_line(ax, ob, color=BLUE, zorder=1, linewidth=3, alpha=1):
     )
 
 
-ax = plt.subplot()
-points = [(2.5, 1.5), (3.5, 2), (3.5, 5), (2.5, 4.5), (1.5, 5), (1.5, 2)]
+nrows = 5
+ncols = 3
+points = [(1.5, 0.5), (2.5, 1.5), (2.5, 3.5), (1.5, 3.25), (0.5, 3.5), (0.5, 1.5)]
 ring = LinearRing(points)
+splits = split_one_geom(ring, nrows, ncols, [1, 0, 0, 0, 1, 0])
+for split in splits:
+    print(list(split.coords))
+
+inter_points = LineString([split.coords[0] for split in splits])
+
+ax = plt.subplot()
 plot_coords(ax, ring)
 plot_line(ax, ring)
-plt.grid(True)
+for i in range(nrows):
+    plt.axhline(i, 0, ncols-1)
+for i in range(ncols):
+    plt.axvline(i, 0, nrows-1)
+plot_coords(ax, inter_points, color=RED)
+
 plt.show()

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -30,25 +30,6 @@ def plot_line(ax, ob, color=BLUE, zorder=1, linewidth=3, alpha=1):
     )
 
 
-nrows = 5
-ncols = 3
-points = [
-    (1.5, 0.25),
-    (2.5, 1.5),
-    (2.5, 3.5),
-    (1.5, 2.25),
-    (0.5, 3.5),
-    (0.5, 1.5),
-]
-ring = orient(Polygon(points), -1)
-b_box = ring.bounds
-
-maxy = b_box[-1]
-miny = b_box[1]
-maxx = b_box[-2]
-minx = b_box[0]
-
-
 def split_along_gridlines(
     exterior_crossings, min_level=0, max_level=0, direction="horizontal"
 ):
@@ -79,6 +60,19 @@ def split_along_gridlines(
             gridline_splits.extend(splits)
     return gridline_splits
 
+
+nrows = 5
+ncols = 3
+points = [
+    (1.5, 0.25),
+    (2.5, 1.5),
+    (2.5, 3.5),
+    (1.5, 2.25),
+    (0.5, 3.5),
+    (0.5, 1.5),
+]
+ring = orient(Polygon(points), -1)
+minx, miny, maxx, maxy = ring.bounds
 
 exterior_splits = split_one_geom(
     ring.exterior, nrows, ncols, [1, 0, 0, 0, 1, 0]

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -1,5 +1,5 @@
-from shapely.geometry.polygon import LinearRing
-from shapely.geometry import LineString
+from shapely.geometry.polygon import LinearRing, orient
+from shapely.geometry import LineString, Polygon
 
 import matplotlib.pyplot as plt
 
@@ -31,16 +31,14 @@ def plot_line(ax, ob, color=BLUE, zorder=1, linewidth=3, alpha=1):
 nrows = 5
 ncols = 3
 points = [(1.5, 0.5), (2.5, 1.5), (2.5, 3.5), (1.5, 3.25), (0.5, 3.5), (0.5, 1.5)]
-ring = LinearRing(points)
-splits = split_one_geom(ring, nrows, ncols, [1, 0, 0, 0, 1, 0])
-for split in splits:
-    print(list(split.coords))
+ring = orient(Polygon(points), -1)
+splits = split_one_geom(ring.exterior, nrows, ncols, [1, 0, 0, 0, 1, 0])
 
 inter_points = LineString([split.coords[0] for split in splits])
 
 ax = plt.subplot()
-plot_coords(ax, ring)
-plot_line(ax, ring)
+plot_coords(ax, ring.exterior)
+plot_line(ax, ring.exterior)
 for i in range(nrows):
     plt.axhline(i, 0, ncols-1)
 for i in range(ncols):

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -8,6 +8,7 @@ from snail.intersections import split as split_one_geom
 BLUE = "#6699cc"
 GRAY = "#999999"
 RED = '#ff3333'
+GREEN = '#339933'
 
 
 def plot_coords(ax, ob, color=GRAY, zorder=1, alpha=1):
@@ -28,13 +29,44 @@ def plot_line(ax, ob, color=BLUE, zorder=1, linewidth=3, alpha=1):
     )
 
 
+def get_crossings(splits):
+    return [split.coords[0] for split in splits]
+
+
 nrows = 5
 ncols = 3
 points = [(1.5, 0.25), (2.5, 1.5), (2.5, 3.5), (1.5, 2.25), (0.5, 3.5), (0.5, 1.5)]
 ring = orient(Polygon(points), -1)
 splits = split_one_geom(ring.exterior, nrows, ncols, [1, 0, 0, 0, 1, 0])
+b_box = ring.bounds
 
-inter_points = LineString([split.coords[0] for split in splits])
+maxy = b_box[-1]
+miny = b_box[1]
+maxx = b_box[-2]
+minx = b_box[0]
+
+inter_points = LineString(get_crossings(splits))
+
+inner_grid_lines = []
+for y in range(int(miny) + 1, int(maxy) + 1):
+    p = [coord for coord in inter_points.coords if coord[1] == y]
+    line2s = list(zip(p, p[1:]))[::2]
+    for line2 in line2s:
+        local_splits = split_one_geom(LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0])
+        inner_grid_lines.extend(
+            local_splits
+        )
+
+for x in range(int(minx) + 1, int(maxx) + 1):
+    p = [coord for coord in inter_points.coords if coord[0] == x]
+    line2s = list(zip(p, p[1:]))[::2]
+    for line2 in line2s:
+        local_splits = split_one_geom(LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0])
+        inner_grid_lines.extend(
+            local_splits
+        )
+        
+        
 
 ax = plt.subplot()
 plot_coords(ax, ring.exterior)
@@ -44,5 +76,8 @@ for i in range(nrows):
 for i in range(ncols):
     plt.axvline(i, 0, nrows-1)
 plot_coords(ax, inter_points, color=RED)
+
+for line in inner_grid_lines:
+    plot_line(ax, line, color=GREEN)
 
 plt.show()

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -1,5 +1,6 @@
 from shapely.geometry.polygon import LinearRing, orient
 from shapely.geometry import LineString, Polygon
+from shapely.ops import polygonize
 
 import matplotlib.pyplot as plt
 
@@ -65,8 +66,7 @@ for x in range(int(minx) + 1, int(maxx) + 1):
         inner_grid_lines.extend(
             local_splits
         )
-        
-        
+polygons = list(polygonize(splits + inner_grid_lines))
 
 ax = plt.subplot()
 plot_coords(ax, ring.exterior)

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -46,11 +46,11 @@ miny = b_box[1]
 maxx = b_box[-2]
 minx = b_box[0]
 
-inter_points = LineString(get_crossings(splits))
-
 inner_grid_lines = []
 for y in range(int(miny) + 1, int(maxy) + 1):
-    p = [coord for coord in inter_points.coords if coord[1] == y]
+    p = list(
+        filter(lambda coord: coord[1] == y, get_crossings(splits))
+    )
     line2s = list(zip(p, p[1:]))[::2]
     for line2 in line2s:
         local_splits = split_one_geom(

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -8,8 +8,8 @@ from snail.intersections import split as split_one_geom
 
 BLUE = "#6699cc"
 GRAY = "#999999"
-RED = '#ff3333'
-GREEN = '#339933'
+RED = "#ff3333"
+GREEN = "#339933"
 
 
 def plot_coords(ax, ob, color=GRAY, zorder=1, alpha=1):
@@ -53,28 +53,29 @@ for y in range(int(miny) + 1, int(maxy) + 1):
     p = [coord for coord in inter_points.coords if coord[1] == y]
     line2s = list(zip(p, p[1:]))[::2]
     for line2 in line2s:
-        local_splits = split_one_geom(LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0])
-        inner_grid_lines.extend(
-            local_splits
+        local_splits = split_one_geom(
+            LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0]
         )
+        inner_grid_lines.extend(local_splits)
 
 for x in range(int(minx) + 1, int(maxx) + 1):
     p = [coord for coord in inter_points.coords if coord[0] == x]
     line2s = list(zip(p, p[1:]))[::2]
     for line2 in line2s:
-        local_splits = split_one_geom(LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0])
-        inner_grid_lines.extend(
-            local_splits
+        local_splits = split_one_geom(
+            LineString(line2), nrows, ncols, [1, 0, 0, 0, 1, 0]
         )
+        inner_grid_lines.extend(local_splits)
+
 polygons = list(polygonize(splits + inner_grid_lines))
 
 ax = plt.subplot()
 plot_coords(ax, ring.exterior)
 plot_line(ax, ring.exterior)
 for i in range(nrows):
-    plt.axhline(i, 0, ncols-1)
+    plt.axhline(i, 0, ncols - 1)
 for i in range(ncols):
-    plt.axvline(i, 0, nrows-1)
+    plt.axvline(i, 0, nrows - 1)
 plot_coords(ax, inter_points, color=RED)
 
 for line in inner_grid_lines:

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -57,17 +57,17 @@ minx = b_box[0]
 
 
 def split_along_gridlines(
-    exterior_splits, min_idx=0, max_idx=0, direction="horizontal"
+    exterior_splits, min_level=0, max_level=0, direction="horizontal"
 ):
     x_or_y = {"horizontal": 1, "vertical": 0}
     gridline_splits = []
-    for idx in range(min_idx, max_idx + 1):
+    for level in range(min_level, max_level + 1):
         # Split horizontal grid lines inside polygon according to
         # intersections with vertical grid lines.
         crossings_on_gridline = list(
             filter(
                 # Returns True if crossing point lies on gridline
-                lambda coord: coord[x_or_y[direction]] == idx,
+                lambda coord: coord[x_or_y[direction]] == level,
                 get_crossings(exterior_splits),
             )
         )
@@ -86,15 +86,15 @@ def split_along_gridlines(
 
 horiz_splits = split_along_gridlines(
     exterior_splits,
-    min_idx=int(miny) + 1,
-    max_idx=int(maxy),
+    min_level=int(miny) + 1,
+    max_level=int(maxy),
     direction="horizontal",
 )
 
 vert_splits = split_along_gridlines(
     exterior_splits,
-    min_idx=int(minx) + 1,
-    max_idx=int(maxx),
+    min_level=int(minx) + 1,
+    max_level=int(maxx),
     direction="vertical",
 )
 

--- a/scripts/polygon2raster/polygon2raster.py
+++ b/scripts/polygon2raster/polygon2raster.py
@@ -30,10 +30,6 @@ def plot_line(ax, ob, color=BLUE, zorder=1, linewidth=3, alpha=1):
     )
 
 
-def get_crossings(splits):
-    return [split.coords[0] for split in splits]
-
-
 nrows = 5
 ncols = 3
 points = [
@@ -45,9 +41,6 @@ points = [
     (0.5, 1.5),
 ]
 ring = orient(Polygon(points), -1)
-exterior_splits = split_one_geom(
-    ring.exterior, nrows, ncols, [1, 0, 0, 0, 1, 0]
-)
 b_box = ring.bounds
 
 maxy = b_box[-1]
@@ -57,7 +50,7 @@ minx = b_box[0]
 
 
 def split_along_gridlines(
-    exterior_splits, min_level=0, max_level=0, direction="horizontal"
+    exterior_crossings, min_level=0, max_level=0, direction="horizontal"
 ):
     x_or_y = {"horizontal": 1, "vertical": 0}
     gridline_splits = []
@@ -68,7 +61,7 @@ def split_along_gridlines(
             filter(
                 # Returns True if crossing point lies on gridline
                 lambda coord: coord[x_or_y[direction]] == level,
-                get_crossings(exterior_splits),
+                exterior_crossings,
             )
         )
         gridline_segments = [
@@ -87,15 +80,20 @@ def split_along_gridlines(
     return gridline_splits
 
 
+exterior_splits = split_one_geom(
+    ring.exterior, nrows, ncols, [1, 0, 0, 0, 1, 0]
+)
+exterior_crossings = [split.coords[0] for split in exterior_splits]
+
 horiz_splits = split_along_gridlines(
-    exterior_splits,
+    exterior_crossings,
     min_level=int(miny) + 1,
     max_level=int(maxy),
     direction="horizontal",
 )
 
 vert_splits = split_along_gridlines(
-    exterior_splits,
+    exterior_crossings,
     min_level=int(minx) + 1,
     max_level=int(maxx),
     direction="vertical",


### PR DESCRIPTION
SIngle Python script in `scripts/poly2raster`. Test case is 
![polygon_scaled](https://user-images.githubusercontent.com/13448239/127994141-f54af5af-4e8f-4324-8174-9ba89901462b.png)

Exterior ring in blue, red dots indicate crossings on exterior ring. Green lines are inner lines, inner crossings are not represented.

Steps:

1. Split exterior ring. This gives a list of splits for the exterior ring (blue splits) but also crossings on the exterior ring (`exterior_crossings`)
2. Split along horizontal gridlines. For each `y` level inside bounding box (y = 1,2 and 3 in example), split segments between two crossings that are inside the polygon. This relies on helper `split_along_gridlines`
3. Split along vertical gridlines (same as 2)
4. Concatenate lists of splits (of type `LineString`) and build split polygons using `shapely.ops.polygonize`

Result:
![Figure_1](https://user-images.githubusercontent.com/13448239/127995756-8e6a5f0d-74ac-4e22-8ac9-0498d15aed21.png)
