### PR TITLE
Fix splitting in case of point on boundary

### DIFF
--- a/src/cpp/find_intersections_linestring.cpp
+++ b/src/cpp/find_intersections_linestring.cpp
@@ -35,13 +35,20 @@ std::vector<linestr> findIntersectionsLineString(Feature feature,
       linestr intersections = raster.findIntersections(line);
       std::vector<linestr> splits = split_linestr(linestr_piece, intersections);
       allsplits.insert(allsplits.end(), splits.begin(), splits.end());
-      linestr_piece = {intersections.back()};
+      if(line.end == intersections.back()) {
+	linestr_piece = {};
+      } else {
+	linestr_piece = {intersections.back()};
+      }
     } else {
       linestr_piece.push_back(linestring.at(i));
     }
   }
-  linestr_piece.push_back(linestring.back());
-  allsplits.push_back(linestr_piece);
+
+  if(linestr_piece.size() > 0) {
+    linestr_piece.push_back(linestring.back());
+    allsplits.push_back(linestr_piece);
+  }
 
   return (allsplits);
 }

--- a/src/cpp/grid.hpp
+++ b/src/cpp/grid.hpp
@@ -107,7 +107,7 @@ struct Grid {
 
     // As long as there is a crossing point BEFORE the end of the line, we can
     // keep looping.
-    while (pE.length() < length || pN.length() < length) {
+    while (pE.length() <= length || pN.length() <= length) {
       // Add the closest crossing point to the vector of grid / graticule
       // crossings.
       if (pE.length() < pN.length()) {

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -97,7 +97,7 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
   // (0,0)         (1,0)          (2,0)
   Config case3;
   case3.linestring = {{1.0, 0.5}, {1.5, 1.0}, {1.5, 2.0}};
-  case3.expected_splits = {{{1.0, 1.5}, {1.5, 1.0}},
+  case3.expected_splits = {{{1.0, 0.5}, {1.5, 1.0}},
 			   {{1.5, 1.0}, {1.5, 2.0}}};
 
   auto test_data = GENERATE_COPY(case1, case2, case3);

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -75,7 +75,32 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
 			   {{1., 0.8333}, {1.125, 1.}},
 			   {{1.125, 1.}, {1.5, 1.5}}};
 
-  auto test_data = GENERATE_COPY(case1, case2);
+  // Linestring points are marked by o:
+  // Intersection points are marked by (o):
+  // +---------------+------(o)-----+
+  // |               |       |      |
+  // |               |       |      |
+  // |               |       |      |
+  // |               |       |      |
+  // |               |       |      |
+  // |               |       |      |
+  // |               |       |      |
+  // +---------------+------(o)-----+
+  // |               |     /        |
+  // |               |    /         |
+  // |               |   /          |
+  // |              (o)-/           |
+  // |               |              |
+  // |               |              |
+  // |               |              |
+  // +---------------+--------------+
+  // (0,0)         (1,0)          (2,0)
+  Config case3;
+  case3.linestring = {{1.0, 0.5}, {1.5, 1.0}, {1.5, 2.0}};
+  case3.expected_splits = {{{1.0, 1.5}, {1.5, 1.0}},
+			   {{1.5, 1.0}, {1.5, 2.0}}};
+
+  auto test_data = GENERATE_COPY(case1, case2, case3);
 
   std::vector<linestr> expected_splits = test_data.expected_splits;
 


### PR DESCRIPTION
This is the case where a point in the linestring is also an intersection point. See #23 

In this case we have to make sure *not* to add the point twice
- Once as an intersection point.
- Once as the next linestring point.

We now only consider the first option.