### PR TITLE
Fix splitting when intersection point falls on on grid crossing

### DIFF
--- a/src/cpp/grid.hpp
+++ b/src/cpp/grid.hpp
@@ -107,24 +107,31 @@ struct Grid {
 
     // As long as there is a crossing point BEFORE the end of the line, we can
     // keep looping.
+    geometry::Vec2<double> p;
     while (pE.length() <= length || pN.length() <= length) {
-      // Add the closest crossing point to the vector of grid / graticule
-      // crossings.
-      if (pE.length() < pN.length()) {
-        crossings.push_back(line.start + pE);
+      // Add the closest crossing point to the vector of grid /
+      // graticule crossings.  If both crossing points overlap then we
+      // update both and it doesn't matter wich one we add to the
+      // vector of crossings.
+      if (pE.length() <= pN.length()) {
+	// Register location of next crossing point before updating
+	p = pE;
         // Update the distance to the next graticule.
         dE += double(east - 1) * cellsize_x;
         // Calculate the position of the crossing point on the next grid /
         // graticule line.
         pE = geometry::Vec2<double>(dE, dE * rise / run);
-      } else {
-        crossings.push_back(line.start + pN);
+      }
+      if (pE.length() >= pN.length()){
+	// Register location of next crossing point before updating
+        p = pN;
         // Update the distance to the next graticule.
         dN += double(north - 1) * cellsize_y;
         // Calculate the position of the crossing point on the next grid /
         // graticule line.
         pN = geometry::Vec2<double>(dN * run / rise, dN);
       }
+      crossings.push_back(line.start + p);
     }
 
     // Return the vector of grid / graticule crossing points that exist bbetween

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -100,7 +100,32 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
   case3.expected_splits = {{{1.0, 0.5}, {1.5, 1.0}},
 			   {{1.5, 1.0}, {1.5, 2.0}}};
 
-  auto test_data = GENERATE_COPY(case1, case2, case3);
+  // Linestring points are marked by o:
+  // Intersection points are marked by (o):
+  // +---------------+--------------+
+  // |               |              |
+  // |               |              |
+  // |               |              |
+  // |               |       o      |
+  // |               |              |
+  // |               |              |
+  // |               |              |
+  // +--------------(o)--------------+
+  // |               |              |
+  // |               |              |
+  // |               |              |
+  // |       o       |              |
+  // |               |              |
+  // |               |              |
+  // |               |              |
+  // +---------------+--------------+
+  // (0,0)         (1,0)          (2,0)
+  Config case4;
+  case4.linestring = {{0.5, 0.5}, {1.5, 1.5}};
+  case4.expected_splits = {{{0.5, 0.5}, {1.0, 1.0}},
+			   {{1.0, 1.0}, {1.5, 1.5}}};
+
+  auto test_data = GENERATE_COPY(case1, case2, case3, case4);
 
   std::vector<linestr> expected_splits = test_data.expected_splits;
 


### PR DESCRIPTION
```
  // Linestring points are marked by o:
  // Intersection points are marked by (o):
  // +---------------+--------------+
  // |               |              |
  // |               |              |
  // |               |              |
  // |               |       o      |
  // |               |              |
  // |               |              |
  // |               |              |
  // +--------------(o)--------------+
  // |               |              |
  // |               |              |
  // |               |              |
  // |       o       |              |
  // |               |              |
  // |               |              |
  // |               |              |
  // +---------------+--------------+
  // (0,0)         (1,0)          (2,0)
```

At the moment the intersection point is registered twice:
- Once as the longitudinal crossing point
- Once as the latitudinal crossing point

```C++
    // In function findIntersections (grid.hpp) 
    // If pE.length() == pN.length() the else case is executed twice for point pE and pN
    while (pE.length() <= length || pN.length() <= length) {
      if (pE.length() < pN.length()) {
        crossings.push_back(line.start + pE);
        dE += double(east - 1) * cellsize_x;
        pE = geometry::Vec2<double>(dE, dE * rise / run);
      } else {
        crossings.push_back(line.start + pN);
        dN += double(north - 1) * cellsize_y;
        pN = geometry::Vec2<double>(dN * run / rise, dN);
      }
```