### PR TITLE
Add core subpackage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-cov
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install -e .
+          pip install .
 
       - name: Lint with flake8
         run: |

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     packages=find_packages('src'),
     package_dir={'': 'src'},
     py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
-    cmake_install_dir="src/snail",
+    cmake_install_dir="src/snail/core",
     include_package_data=True,
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     url='https://github.com/nismod/snail',
     packages=find_packages('src'),
     package_dir={'': 'src'},
-    py_modules=[splitext(basename(path))[0] for path in glob('src/*.py')],
     cmake_install_dir="src/snail/core",
     include_package_data=True,
     zip_safe=False,

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -6,7 +6,7 @@ import rasterio
 from pandas import read_csv
 from igraph import Graph
 
-from snail.snail_intersections import split, raster2split
+from snail.multi_intersections import split, raster2split
 from snail.routing import shortest_paths
 
 

--- a/src/snail/core/__init__.py
+++ b/src/snail/core/__init__.py
@@ -1,0 +1,1 @@
+from . import intersections

--- a/src/snail/multi_intersections.py
+++ b/src/snail/multi_intersections.py
@@ -2,9 +2,9 @@ import geopandas as gpd
 from shapely.geometry import LineString, Polygon
 from shapely.ops import polygonize
 
-from snail.intersections import split_linestring
-from snail.intersections import split_polygon
-from snail.intersections import get_cell_indices
+from snail.core.intersections import split_linestring
+from snail.core.intersections import split_polygon
+from snail.core.intersections import get_cell_indices
 
 
 def split_linestrings(vector_data, raster_data):

--- a/tests/core/test_intersections.py
+++ b/tests/core/test_intersections.py
@@ -2,7 +2,7 @@ import unittest
 
 from shapely.geometry import LineString
 
-from snail import intersections
+import snail.core.intersections
 
 
 class TestIntersections(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestIntersections(unittest.TestCase):
         for i, test_data in enumerate(zip(test_linestrings, expected)):
             test_linestring, expected_splits = test_data
             with self.subTest(i=i):
-                splits = intersections.split_linestring(
+                splits = snail.core.intersections.split_linestring(
                     test_linestring, self.nrows, self.ncols, self.transform
                 )
                 self.assertTrue(
@@ -53,7 +53,7 @@ class TestIntersections(unittest.TestCase):
 
         for i, test_linestring in enumerate(test_linestrings):
             with self.subTest(i=i):
-                cell_indices = intersections.get_cell_indices(
+                cell_indices = snail.core.intersections.get_cell_indices(
                     test_linestring, self.nrows, self.ncols, self.transform
                 )
                 self.assertEqual(cell_indices, expected_cell_indices[i])


### PR DESCRIPTION
New subpackage in `snail/core`. When installed, this package contains the `intersections` compiled module. This subpackage also contains a init init file
    
```python
# src/snail/core/__init__.py
from . import intersections
```

Which means that the object in the "core" compiled `intersections` module are accessible as, e.g.

```python
import snail.core.intersections
from snail.core.intersections import split_polygon, split_linestring
```

**Note** that C++ code remains in `src/cpp` as before. We tell scikit-build to install the compiled extension the right place:

```python
setup(
    # ...
    cmake_install_dir="src/snail/core",
    # ...
)
```
    
Regular installation works, but not editable one. The `snail.egg-link` points to the top level `snail` (containing `src`) instead of `snail/src`. This is a reccent issue reported in the scikit-build tracker, see [scikit-build#546](https://github.com/scikit-build/scikit-build/issues/546). I think a fix is under way. 