### PR TITLE
Fix edge cases

### DIFF
--- a/src/cpp/operations.cpp
+++ b/src/cpp/operations.cpp
@@ -61,44 +61,111 @@ findIntersectionsLineString(geometry::LineString linestring,
   return (allsplits);
 }
 
-bool isOnGridLine(geometry::Coord point, Direction direction,
-                  int level) {
+bool isOnGridLine(geometry::Coord point, Direction direction, int level) {
   switch (direction) {
-    case Direction::horizontal: return (point.y == level);
-    case Direction::vertical:   return (point.x == level);
-    default: return false;
+  case Direction::horizontal:
+    return (point.y == level);
+  case Direction::vertical:
+    return (point.x == level);
+  default:
+    return false;
+  }
+}
+
+// This aims to filter out vertices exactly on the line which should not be
+// considered as actual crossing points.
+//
+//              |....../
+//  >>-----x----o-----o-----  (don't include x)
+//        /.\   |..../
+//
+// TODO figure out what to do when some portion of the boundary is already
+// along the grid line. This is a legitimate case for odd number of crossings:
+//
+//              |......|
+//  >>-----o====o------o---
+//        /............|
+//
+// Try something like "if the previous crossing (in sorted order) was also the
+// immediately previous point on the exterior, discard it in favour of the
+// current exterior/crossing point".
+bool crossesGridLine(geometry::Coord prev, geometry::Coord next,
+                     Direction direction, int level) {
+  switch (direction) {
+  case Direction::horizontal:
+    return (prev.y <= level && next.y >= level) ||
+           (prev.y >= level && next.y <= level);
+  case Direction::vertical:
+    return (prev.x <= level && next.x >= level) ||
+           (prev.x >= level && next.x <= level);
+  default:
+    return false;
   }
 }
 
 std::vector<linestr> splitAlongGridlines(linestr exterior_crossings,
                                          int min_level, int max_level,
-                                         Direction direction,
-                                         grid::Grid grid) {
+                                         Direction direction, grid::Grid grid) {
   std::vector<geometry::Coord> crossings_on_gridline;
   std::vector<linestr> gridline_splits;
   for (int level = min_level; level <= max_level; level++) {
-    // filter to find crossings at this level
-    std::copy_if(
-      exterior_crossings.begin(),
-      exterior_crossings.end(),
-      std::back_inserter(crossings_on_gridline),
-      [direction, level](geometry::Coord p) {
-        return isOnGridLine(p, direction, level);
+    // find crossings at this level
+    for (auto curr = exterior_crossings.begin();
+         curr != exterior_crossings.end(); curr++) {
+
+      // pick previous point on ring (wrap around)
+      auto prev = (curr == exterior_crossings.begin())
+                      ? (exterior_crossings.end() - 1)
+                      : (curr - 1);
+
+      // skip duplicates in sequence
+      if (*curr == *prev) {
+        continue;
       }
-    );
+      // pick next point on ring (wrap around)
+      auto next = ((curr + 1) == exterior_crossings.end())
+                      ? exterior_crossings.begin()
+                      : (curr + 1);
+      // include if on the current line and prev/next are on opposite sides
+      if (isOnGridLine(*curr, direction, level) &&
+          crossesGridLine(*prev, *next, direction, level)) {
+        crossings_on_gridline.push_back(*curr);
+      }
+    }
+
+    // sort crossings by x or y coordinate
+    std::sort(crossings_on_gridline.begin(), crossings_on_gridline.end(),
+              [direction](const geometry::Coord &a, const geometry::Coord &b) {
+                switch (direction) {
+                case Direction::horizontal:
+                  return a.x < b.x;
+                case Direction::vertical:
+                  return a.y < b.y;
+                default:
+                  return false;
+                }
+              });
+
+    if (crossings_on_gridline.size() % 2 != 0) {
+      utils::Exception("Expected even number of crossings on gridline.");
+      break;
+    }
 
     // step through each pair of crossings (0,1) (2,3) ...
     auto itr = crossings_on_gridline.begin();
     while (itr != crossings_on_gridline.end()) {
+      // Bail before trying to access beyond the end
+      // Could remove this if we check earlier for even-length vector?
+      if (std::next(itr) == crossings_on_gridline.end()) {
+        utils::Exception("Out of range error.");
+        break;
+      }
       // construct a LineString along the gridline between these two crossings
-      geometry::LineString segment({
-        (*itr),
-        (*(std::next(itr)))
-      });
+      geometry::LineString segment({(*itr), (*(std::next(itr)))});
 
       std::vector<linestr> splits = findIntersectionsLineString(segment, grid);
-      gridline_splits.insert(
-        gridline_splits.end(), splits.begin(), splits.end());
+      gridline_splits.insert(gridline_splits.end(), splits.begin(),
+                             splits.end());
 
       // step forward two
       std::advance(itr, 2);

--- a/tests/cpp/tests_intersections.cpp
+++ b/tests/cpp/tests_intersections.cpp
@@ -125,7 +125,43 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
   case4.expected_splits = {{{0.5, 0.5}, {1.0, 1.0}},
 			   {{1.0, 1.0}, {1.5, 1.5}}};
 
-  auto test_data = GENERATE_COPY(case1, case2, case3, case4);
+  // vertical along gridline
+  Config case5;
+  case5.linestring = {{0.5, 1.0}, {2.5, 1.0}};
+  case5.expected_splits = {{{0.5, 1.0}, {1.0, 1.0}},
+                           {{1.0, 1.0}, {2.0, 1.0}},
+                           {{2.0, 1.0}, {2.5, 1.0}}};
+
+  // horizontal along gridline
+  Config case6;
+  case6.linestring = {{0.0, 1.1}, {0.0, 4.7}};
+  case6.expected_splits = {{{0.0, 1.1}, {0.0, 2.0}},
+                           {{0.0, 2.0}, {0.0, 3.0}},
+                           {{0.0, 3.0}, {0.0, 4.0}},
+                           {{0.0, 4.0}, {0.0, 4.7}}};
+
+  // Includes single point on gridline (was duplicating)
+  Config case7;
+  case7.linestring = {{2.9, 2.2}, {2., 1.5}, {0.9, 1.5}};
+  case7.expected_splits = {{{2.9, 2.2}, {2.64286, 2}},
+                           {{2.64286, 2.}, {2., 1.5}},
+                           {{2., 1.5}, {1., 1.5}},
+                           {{1., 1.5}, {0.9, 1.5}}};
+
+  // V shape with floating point error
+  Config case8;
+  case8.linestring = {
+    {0.5,1.1}, {1.5, 0.9}, {2.5, 1.1}
+  };
+  case8.expected_splits = {
+    {{0.5,1.1}, {1.,1.}},
+    {{1.,1.}, {1.5,0.9}, {2.,1.}},
+    {{2.,1.}, {2.5,1.1}}
+  };
+
+  // TODO case7, case8
+  auto test_data = GENERATE_COPY(case1, case2, case3, case4, case5, case6);
+
 
   std::vector<linestr> expected_splits = test_data.expected_splits;
 
@@ -134,7 +170,20 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
 
   // Using default Affine transform(1, 0, 0, 0, 1, 0)
   snail::grid::Grid test_raster(2, 2, snail::transform::Affine());
-  std::vector<linestr> splits = snail::operations::findIntersectionsLineString(line, test_raster);
+  std::vector<linestr> splits =
+      snail::operations::findIntersectionsLineString(line, test_raster);
+
+  // DEBUG
+  /*
+  std::cout.precision(18);
+  for (int i = 0; i < splits.size(); i++) {
+    std::cout << "Split" << i << "\n";
+    for (int j = 0; j < splits[i].size(); j++) {
+      snail::geometry::Coord point = splits[i][j];
+      std::cout << "  " << point.x << "," << point.y << "\n";
+    }
+  }
+  */
 
   // Test that we're getting the expected number of splits
   REQUIRE(splits.size() == expected_splits.size());
@@ -156,24 +205,36 @@ TEST_CASE("LineStrings are decomposed", "[decomposition]") {
 
 
 TEST_CASE("Split with different grid", "[decomposition]") {
+  Config case1;
+  case1.expected_splits = {
+      {{191483.13281982497, 2044523.5152593486}, {191487.679611496, 2044520.0}},
+      {{191487.679611496, 2044520.0}, {191565.0, 2044460.22131688}},
+      {{191565.0, 2044460.22131688}, {191604.089585794, 2044430.0}},
+      {{191604.089585794, 2044430.0},
+       {191618.28009818937, 2044419.0288944514}}};
+  case1.linestring = {{191483.13281982497, 2044523.5152593486},
+                      {191618.28009818937, 2044419.0288944514}};
 
-  std::vector<linestr> expected_splits = {
-    {{191483.13281982497, 2044523.5152593486}, {191487.679611496, 2044520.0}},
-    {{191487.679611496, 2044520.0}, {191565.0, 2044460.22131688}},
-    {{191565.0, 2044460.22131688}, {191604.089585794, 2044430.0}},
-    {{191604.089585794, 2044430.0}, {191618.28009818937, 2044419.0288944514}}
-  };
+  Config case2;
+  case2.expected_splits = {
+      {{190040.9085973615, 2043440.0}, {190035.0, 2043440.0}},
+      {{190035.0, 2043440.0}, {189945.0, 2043440.0}},
+      {{189945.0, 2043440.0}, {189855.0, 2043440.0}},
+      {{189855.0, 2043440.0}, {189819.85637632824, 2043440.0}}};
+  case2.linestring = {{190040.9085973615, 2043440.0},
+                      {189819.85637632824, 2043440.0}};
 
-  linestr geom = {
-    {191483.13281982497, 2044523.5152593486},
-    {191618.28009818937, 2044419.0288944514}
-  };
+  auto test_data = GENERATE_COPY(case1, case2);
+
+  std::vector<linestr> expected_splits = test_data.expected_splits;
+  linestr geom = test_data.linestring;
   snail::geometry::LineString line(geom);
 
-  snail::grid::Grid test_raster(2, 2, snail::transform::Affine(
-    90.0, 0.0, 132165.0, 0.0, -90.0, 2055230.0
-  ));
-  std::vector<linestr> splits = snail::operations::findIntersectionsLineString(line, test_raster);
+  snail::grid::Grid test_raster(
+      2, 2,
+      snail::transform::Affine(90.0, 0.0, 132165.0, 0.0, -90.0, 2055230.0));
+  std::vector<linestr> splits =
+      snail::operations::findIntersectionsLineString(line, test_raster);
 
   // Test that we're getting the expected number of splits
   REQUIRE(splits.size() == expected_splits.size());
@@ -229,8 +290,10 @@ TEST_CASE("Exterior ring splits to gridlines", "[decomposition]") {
     {0.5, 0.5}, {1., 0.5}, {1.5, 1.}, {1., 1.}
   };
   case1.expected_splits = {
-    {{1.5, 1.}, {1., 1.}}, // TODO check, would actually expect left-to-right
+      {{1., 1.}, {1.5, 1.}},
   };
+  case1.direction = snail::operations::Direction::horizontal;
+
   SplitGridConfig case2;
   case2.exterior_crossings = {
     {0.5, 0.5}, {1., 0.5}, {1.5, 1.}, {1., 1.}
@@ -240,7 +303,53 @@ TEST_CASE("Exterior ring splits to gridlines", "[decomposition]") {
   };
   case2.direction = snail::operations::Direction::vertical;
 
-  auto test_data = GENERATE_COPY(case1, case2);
+  // Concave shape
+  // +------+------+------+
+  // |      |      |      |
+  // | o--o |      | o--o |
+  // | |..| |      | |..| |
+  // +(o==o)+------+(o==o)+
+  // | |..| |      | |..| |
+  // | |..o(o)----(o)o..| |
+  // | |....‖......‖....| |
+  // +(o)===+======+===(o)+
+  // | |....‖......‖....| |
+  // | |....‖......‖....| |
+  // | o---(o)----(o)---o |
+  // +------+------+------+
+  // 0      1      2      3
+  SplitGridConfig case3;
+  case3.exterior_crossings = {
+      {0.1, 0.1}, {1., 0.1},  {2., 0.1},  {2.9, 0.1}, // bottom edge
+      {2.9, 1.},  {2.9, 2.},  {2.9, 2.2},             // right edge
+      {2.1, 2.2}, {2.1, 2.},  {2.1, 1.5},             // inside right
+      {2., 1.5},  {1., 1.5},  {0.9, 1.5},             // inside top
+      {0.9, 2.},  {0.9, 2.2},                         // inside left
+      {0.1, 2.2}, {0.1, 2.},  {0.1, 1.},  {0.1, 0.1}  // left edge
+  };
+  case3.expected_splits = {// full width interior
+                           {{0.1, 1.}, {1., 1.}},
+                           {{1., 1.}, {2., 1.}},
+                           {{2., 1.}, {2.9, 1.}},
+                           // left tower
+                           {{0.1, 2.}, {0.9, 2.}},
+                           // right tower
+                           {{2.1, 2.}, {2.9, 2.}}};
+  case3.direction = snail::operations::Direction::horizontal;
+
+  // Kite shape
+  SplitGridConfig case4;
+  case4.exterior_crossings = {
+    {0.5, 1.25}, {1.,1.}, {1.5, 0.75}, {2.,1.}, {2.5, 1.25},
+    {2.25,1.}, {2.,0.75}, {1.5, 0.25}, {1.,0.75}, {0.75, 1.}
+  };
+  case4.expected_splits = {
+    {{0.75, 1.0}, {1.0, 1.0}},
+    {{2.0, 1.0}, {2.25, 1.0}}
+  };
+  case4.direction = snail::operations::Direction::horizontal;
+
+  auto test_data = GENERATE_COPY(case1, case2, case3, case4);
 
   std::vector<linestr> expected_splits = test_data.expected_splits;
 


### PR DESCRIPTION
This PR picks up a few issues from running lots of examples: (1) handle zero run/rise in a special case, (2) add a detailed error message in final "else" case of `Grid::findIntersections`, (3) fix ordering and duplicates in `operations::splitAlongGridlines` and (4) add failing test cases (not currently enabled).

(1) Zero run or rise happens with horizontal or vertical lines, which are very common in splitting polygons along grid.

(2) The final "else" case in `Grid::findIntersections` occurs when pN and pE length are not comparable,
comes up with very small or large floats leading to inf/nan. 

TODO: find a reproducible example with small/large numbers and think this through.

(3) For the gridline crossings:
- sort along axis direction, so points are considered in order
- skip duplicate points
- skip "touching" points where the line doesn't cross
- add guards around two-at-a-time iterator to avoid going out of range

TODO: handle the case where some portion of the boundary extends along the grid line. This is a legitimate case for odd number of crossings:
```
              |......|
  >>-----o====o------o---
        /............|
```
Idea: try something like "if the previous crossing (in sorted order) was also the immediately previous point on the exterior, discard it in favour of the current exterior/crossing point".

(4) Failing test cases:

TODO: expect case7 (outputting an extra split around a point on the boundary) and case8 (off-by-a-little floating point) to fail in tests_intersections.cpp line 163