### PR TITLE
Replace python-igraph dependency by igraph

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "pandera",
     "pyarrow",
     "pyogrio",
-    "python-igraph",
+    "igraph",
     "rasterio",
     "shapely",
     "scipy"


### PR DESCRIPTION
Please see https://github.com/igraph/python-igraph/issues/699 for an explanation. Note that the renaming applies to PyPI only, not Conda.