### PR TITLE
Use rioxarray to read to chunked dask array, add 'lazy' flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,13 @@ snail split \
     --features lines.geojson \
     --raster gridded_data.tif \
     --attribute \
+    --lazy-rasters \
     --output split_lines_with_raster_values.geojson
 ```
+
+Adding `--lazy-rasters` keeps large raster bands on disk and fetches values
+lazily via `xarray`/`dask` (install additional dependencies with `pip install
+snail[lazy]`).
 
 Split multiple vector feature files along the grids defined by multiple raster files, attributing all raster values:
 
@@ -72,6 +77,9 @@ snail process -fs features.csv -rs rasters.csv
 ```
 
 Where at a minimum, each CSV has a column `path` with the path to each file.
+
+The `--lazy-rasters` flag can be supplied to `snail process` when working with
+large rasters.
 
 ### Transform
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,7 +83,12 @@ Split features on a grid defined by a GeoTIFF, optionally adding the values from
         --features lines.geojson \
         --raster gridded_data.tif \
         --attribute \
+        --lazy-rasters \
         --output split_lines_with_raster_values.geojson
+
+Add ``--lazy-rasters`` to keep raster bands on disk and fetch values lazily via
+``xarray``/``dask`` (install the additional dependencies with ``pip install
+snail[lazy]``).
 
 
 Split multiple vector feature files along the grids defined by multiple raster files, attributing all raster values::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["affine", "black", "hilbertcurve", "nbstripout", "pytest-cov", "pytest"]
+lazy = ["dask[array]", "rioxarray", "xarray"]
 docs = ["sphinx", "nbsphinx", "sphinx_gallery", "numpydoc"]
 tutorials = [
     "contextily",

--- a/src/snail/cli.py
+++ b/src/snail/cli.py
@@ -108,6 +108,13 @@ def snail(args=None):
         help="Column name to use when attributing raster values, defaults to raster filename",
     )
     parser_split.add_argument(
+        "--lazy-rasters",
+        action="store_true",
+        help=(
+            "Read raster bands lazily with xarray/dask when attributing values."
+        ),
+    )
+    parser_split.add_argument(
         "-o",
         "--output",
         type=str,
@@ -138,6 +145,11 @@ def snail(args=None):
         type=str,
         required=True,
         help="CSV file with raster layers",
+    )
+    parser_process.add_argument(
+        "--lazy-rasters",
+        action="store_true",
+        help="Read raster bands lazily with xarray/dask during processing.",
     )
     parser_process.set_defaults(func=process)
 
@@ -249,7 +261,9 @@ def split(args):
                 band_index,
             )
             band_data = read_raster_band_data(
-                args.raster, band_number=int(band_index)
+                args.raster,
+                band_number=int(band_index),
+                lazy=args.lazy_rasters,
             )
             splits[key] = get_raster_values_for_splits(splits, band_data)
 
@@ -293,10 +307,23 @@ def process(args):
         )
 
     for vector_layer in vector_layers.itertuples():
-        _process_layer(vector_layer, transforms, rasters, args.experimental)
+        _process_layer(
+            vector_layer,
+            transforms,
+            rasters,
+            experimental=args.experimental,
+            lazy=args.lazy_rasters,
+        )
 
 
-def _process_layer(vector_layer, transforms, rasters, experimental=False):
+def _process_layer(
+    vector_layer,
+    transforms,
+    rasters,
+    *,
+    experimental: bool = False,
+    lazy: bool = False,
+):
     vector_path = Path(vector_layer.path)
     layer = getattr(vector_layer, "layer", None)
     logging.info("Processing %s", vector_path.name)
@@ -308,13 +335,13 @@ def _process_layer(vector_layer, transforms, rasters, experimental=False):
     if "Point" in geom_type:
         prepared = prepare_points(features)
         split = split_features_for_rasters(prepared, transforms, split_points)
-        with_data = associate_raster_files(split, rasters)
+        with_data = associate_raster_files(split, rasters, lazy=lazy)
     elif "LineString" in geom_type:
         prepared = prepare_linestrings(features)
         split = split_features_for_rasters(
             prepared, transforms, split_linestrings
         )
-        with_data = associate_raster_files(split, rasters)
+        with_data = associate_raster_files(split, rasters, lazy=lazy)
     elif "Polygon" in geom_type:
         prepared = prepare_polygons(features)
         if experimental:
@@ -326,7 +353,7 @@ def _process_layer(vector_layer, transforms, rasters, experimental=False):
             split = split_features_for_rasters(
                 prepared, transforms, split_polygons
             )
-        with_data = associate_raster_files(split, rasters)
+        with_data = associate_raster_files(split, rasters, lazy=lazy)
     else:
         raise ValueError(f"Could not process vector data of type {geom_type}")
 

--- a/src/snail/intersection.py
+++ b/src/snail/intersection.py
@@ -2,12 +2,27 @@ import logging
 import math
 import os
 from dataclasses import dataclass
-from typing import Callable, List, Tuple, Union
+from typing import TYPE_CHECKING, Callable, List, Tuple, Union
 
 import geopandas
 import numpy
 import pandas
 import rasterio
+
+try:
+    import dask.array as _dask_array
+except ImportError:  # pragma: no cover - optional dependency
+    _dask_array = None
+
+try:
+    import xarray as _xarray
+except ImportError:  # pragma: no cover - optional dependency
+    _xarray = None
+
+if TYPE_CHECKING:
+    import dask.array
+    import xarray
+
 from shapely import box
 from shapely.geometry import mapping, shape
 from shapely.ops import linemerge, polygonize
@@ -289,7 +304,11 @@ def _set_precision(geom, precision):
 
 def get_raster_values_for_splits(
     splits: pandas.DataFrame,
-    data: numpy.ndarray,
+    data: Union[
+        numpy.ndarray,
+        "xarray.DataArray",
+        "dask.array.Array",
+    ],
     index_i: str = "index_i",
     index_j: str = "index_j",
 ) -> pandas.Series:
@@ -306,8 +325,9 @@ def get_raster_values_for_splits(
         Table of features, each with cell indices
         to look up raster pixel. Indices must be stored under columns with
         names referenced by index_i and index_j.
-    data:  numpy.ndarray
-        Raster data (2D array)
+    data: numpy.ndarray or xarray.DataArray or dask.array.Array
+        2D raster values. DataArray inputs must have two spatial
+        dimensions (band dimensions should be squeezed prior to calling).
     index_i: str
         Column name for i-indices
     index_j: str
@@ -318,13 +338,59 @@ def get_raster_values_for_splits(
     pd.Series
         Series of raster values, with same row indexing as df.
     """
-    # 2D numpy indexing is j, i (i.e. row, column)
-    with_data = pandas.Series(
-        index=splits.index, data=data[splits[index_j], splits[index_i]]
+    indices_i = splits[index_i].to_numpy()
+    indices_j = splits[index_j].to_numpy()
+    valid_mask = (indices_i >= 0) & (indices_j >= 0)
+    valid_positions = numpy.nonzero(valid_mask)[0]
+
+    if len(valid_positions) == 0:
+        return _build_series(splits.index, valid_positions, numpy.array([]))
+
+    if isinstance(data, numpy.ndarray):
+        backing_data = data
+    elif isinstance(data, _dask_array.Array):
+        backing_data = data
+    elif isinstance(data, _xarray.DataArray):
+        backing_data = data.data
+    else:
+        raise TypeError(
+            "Unsupported raster data type; expected numpy.ndarray, xarray.DataArray or dask.array.Array."
+        )
+
+    indices_i_valid = indices_i[valid_positions]
+    indices_j_valid = indices_j[valid_positions]
+
+    if isinstance(backing_data, numpy.ndarray):
+        splits_values = backing_data[indices_j_valid, indices_i_valid]
+        return _build_series(splits.index, valid_positions, splits_values)
+
+    elif isinstance(backing_data, _dask_array.Array):
+        splits_values_da = backing_data.vindex[
+            indices_j_valid, indices_i_valid
+        ]
+        splits_values = numpy.asarray(splits_values_da.compute())
+        return _build_series(splits.index, valid_positions, splits_values)
+
+    else:
+        raise NotImplementedError(
+            "data array backends must be NumPy or Dask arrays."
+        )
+
+
+def _build_series(
+    index: pandas.Index,
+    positions: numpy.ndarray,
+    values: numpy.ndarray,
+) -> pandas.Series:
+    """Create a Series indexed by index, filled with specific values at given
+    positions, default numpy.nan.
+    """
+    series = pandas.Series(
+        numpy.full(len(index), numpy.nan), index=index, dtype="float64"
     )
-    # set NaN for out-of-bounds
-    with_data[(splits[index_i] == -1) | (splits[index_j] == -1)] = numpy.nan
-    return with_data
+    if len(positions):
+        series.iloc[positions] = values
+    return series
 
 
 def apply_indices(

--- a/src/snail/io.py
+++ b/src/snail/io.py
@@ -1,16 +1,24 @@
 import importlib.util
 import logging
-from typing import List, Tuple
+from typing import List, Tuple, TYPE_CHECKING, Union
 
 import geopandas
 import numpy
 import pandas
 import rasterio
 
+try:
+    import rioxarray as _rioxarray
+except ImportError as exc:
+    _rioxarray = None
+
+if TYPE_CHECKING:  # pragma: no cover
+    import xarray
+
 from snail.intersection import GridDefinition, get_raster_values_for_splits
 
 
-def associate_raster_files(splits, rasters):
+def associate_raster_files(splits, rasters, lazy: bool = False):
     """Read values from a list of raster files for a set of indexed split geometries
 
     Parameters
@@ -22,6 +30,10 @@ def associate_raster_files(splits, rasters):
     rasters: pandas.DataFrame
         table of raster metadata with columns: key, grid_id, path, bands
 
+    lazy: bool, default False
+        When True, raster bands are opened lazily via xarray/dask. Requires
+        optional dependencies (xarray, dask, rioxarray).
+
     Returns
     -------
     pandas.DataFrame
@@ -32,7 +44,7 @@ def associate_raster_files(splits, rasters):
     raster_data: dict[str, pandas.Series] = {}
 
     # associate values
-    for raster, band_number, band_data in read_rasters(rasters):
+    for raster, band_number, band_data in read_rasters(rasters, lazy=lazy):
         logging.info(
             "Associating values from raster %s grid %s band %s",
             raster.key,
@@ -52,20 +64,31 @@ def associate_raster_files(splits, rasters):
     return splits
 
 
-def read_rasters(rasters):
+def read_rasters(rasters, lazy: bool = False):
     for raster in rasters.itertuples():
         for band_number in raster.bands:
             yield raster, band_number, read_raster_band_data(
-                raster.path, band_number
+                raster.path, band_number, lazy=lazy
             )
 
 
 def read_raster_band_data(
     fname: str,
     band_number: int = 1,
-) -> numpy.ndarray:
-    with rasterio.open(fname) as dataset:
-        band_data: numpy.ndarray = dataset.read(band_number)
+    lazy: bool = False,
+) -> Union[numpy.ndarray, "xarray.DataArray"]:
+    if not lazy:
+        with rasterio.open(fname) as dataset:
+            band_data: numpy.ndarray = dataset.read(band_number)
+    else:
+        if _rioxarray is None:
+            raise RuntimeError(
+                "Lazy raster reading requires optional dependencies, including "
+                "xarray, dask and rioxarray. Try 'pip install nismod-snail[lazy]'"
+            )
+
+        data_array = _rioxarray.open_rasterio(fname, chunks="auto")
+        band_data = data_array.isel(band=band_number - 1).squeeze(drop=True)
     return band_data
 
 

--- a/tests/test_intersection.py
+++ b/tests/test_intersection.py
@@ -2,9 +2,11 @@ import os
 
 import geopandas as gpd
 import numpy as np
+import pandas as pd
 import pytest
 from hilbertcurve.hilbertcurve import HilbertCurve
 from numpy.testing import assert_array_equal
+from pandas.testing import assert_series_equal
 from rasterio.crs import CRS
 from shapely.geometry import LineString, Point, Polygon
 from shapely.geometry.polygon import LinearRing, orient
@@ -12,6 +14,7 @@ from shapely.geometry.polygon import LinearRing, orient
 from snail.intersection import (
     aggregate_values_to_grid,
     GridDefinition,
+    get_raster_values_for_splits,
     split_linestrings,
     split_polygons,
     generate_grid_boxes,
@@ -197,6 +200,52 @@ class TestSnailIntersections:
             expected_geom = expected.iloc[i, 1]
             assert actual_geom.equals(expected_geom)
         assert_array_equal(actual["col1"].values, expected["col1"].values)
+
+
+def _make_sample_splits():
+    return pd.DataFrame(
+        {
+            "index_i": [0, 1, 2, -1],
+            "index_j": [0, 0, 1, -1],
+        }
+    )
+
+
+def _expected_series(index):
+    return pd.Series(
+        [100.0, 101.0, 202.0, np.nan],
+        index=index,
+        dtype=float,
+    )
+
+
+def test_get_raster_values_for_splits_numpy_handles_invalid_indices():
+    splits = _make_sample_splits()
+    raster = np.array([[100, 101, 102], [200, 201, 202]], dtype=float)
+    result = get_raster_values_for_splits(splits, raster)
+    assert_series_equal(result, _expected_series(splits.index), check_dtype=False)
+
+
+def test_get_raster_values_for_splits_supports_xarray():
+    xr = pytest.importorskip("xarray")
+    splits = _make_sample_splits()
+    raster = xr.DataArray(
+        np.array([[100, 101, 102], [200, 201, 202]], dtype=float),
+        dims=("y", "x"),
+    )
+    result = get_raster_values_for_splits(splits, raster)
+    assert_series_equal(result, _expected_series(splits.index), check_dtype=False)
+
+
+def test_get_raster_values_for_splits_supports_dask():
+    da = pytest.importorskip("dask.array")
+    splits = _make_sample_splits()
+    raster = da.from_array(
+        np.array([[100, 101, 102], [200, 201, 202]], dtype=float),
+        chunks=(1, 2),
+    )
+    result = get_raster_values_for_splits(splits, raster)
+    assert_series_equal(result, _expected_series(splits.index), check_dtype=False)
 
 
 def test_box_geom_bounds():


### PR DESCRIPTION
Aims to close #58

Keeps band-reading API and general assumption of tiffs and 2D data arrays,
but adds rioxarray, dask and xarray as optional dependencies that can handle
lazy reading of chunked data - works well in side experiments with VRT built
from ~100s of TIFFs for global raster layer and national vector layer.

